### PR TITLE
ENH: add individual val select ex to 09-data-frames episode

### DIFF
--- a/_episodes/09-data-frames.md
+++ b/_episodes/09-data-frames.md
@@ -15,7 +15,7 @@ keypoints:
 ---
 FIXME: lesson content.
 
-> ## Selection
+> ## Selection of Individual Values
 > 
 > Assume Pandas has been imported into your notebook
 > and the Gapminder GDP data for Europe has been loaded:
@@ -23,7 +23,22 @@ FIXME: lesson content.
 > ~~~
 > import pandas as pd
 > 
-> data = pd.read_csv('data/gapminder_gd_europe.csv')
+> df = pd.read_csv('data/gapminder_gdp_europe.csv', index_col='country')
+> ~~~
+> {: .source}
+> 
+> Write an expression to find the Per Capita GDP of Albania in 2007.
+{: .challenge}
+
+> ## Selection of Rows
+> 
+> Assume Pandas has been imported into your notebook
+> and the Gapminder GDP data for Europe has been loaded:
+> 
+> ~~~
+> import pandas as pd
+> 
+> data = pd.read_csv('data/gapminder_gdp_europe.csv')
 > ~~~
 > {: .source}
 > 


### PR DESCRIPTION
This is an instructor training PR that adds a simple exercise to the 09-data-frames episode.  I chose to make the csv loading a little more complicated than the minimal command (using the `index_col` argument) in order to allow the difference between `df.loc` and `df.iloc` to surface in the classroom, but I understand if there is a preference for simplicity at this point.