### PR TITLE
Fix some typos

### DIFF
--- a/_episodes/04-built-in.md
+++ b/_episodes/04-built-in.md
@@ -90,7 +90,7 @@ round(3.712)
 ~~~
 {: .output}
 
-*   We can specify the number of decimal places we ant.
+*   We can specify the number of decimal places we want.
 
 ~~~
 round(3.712, 1)

--- a/_episodes/05-error-messages.md
+++ b/_episodes/05-error-messages.md
@@ -25,7 +25,7 @@ adjustment = 0.5   # Neither is this - anything after '#' is ignored.
 
 ## Python reports a syntax error when it can't understand the source of a program.
 
-*   Won't even try to run the program if it can be parsed.
+*   Won't even try to run the program if it can't be parsed.
 
 ~~~
 # Forgot to close the quotation marks around the string.

--- a/_episodes/06-libraries.md
+++ b/_episodes/06-libraries.md
@@ -45,7 +45,7 @@ cos(pi) is -1.0
 {: .output}
 
 *   Have to refer to each item with the library's name.
-    *   `math.cos(pi)` won't work: the reference to `pi` doesn't somewhow "inherit" the function's reference to `math`.
+    *   `math.cos(pi)` won't work: the reference to `pi` doesn't somehow "inherit" the function's reference to `math`.
 
 ## Use `help` to find out more about a library's contents.
 

--- a/_episodes/11-data-frames.md
+++ b/_episodes/11-data-frames.md
@@ -3,7 +3,7 @@ title: "Pandas Data Frames"
 teaching: 10
 exercises: 10
 questions:
-- "How can do statistical analysis of tabular data?"
+- "How can I do statistical analysis of tabular data?"
 objectives:
 - "Select individual values from a Pandas data frame."
 - "Select entire rows or entire columns from a data frame."

--- a/_episodes/15-conditionals.md
+++ b/_episodes/15-conditionals.md
@@ -34,7 +34,7 @@ if mass > 3.0:
 ~~~
 {: .python}
 ~~~
-3.0 is large
+3.54 is large
 ~~~
 {: .output}
 

--- a/_episodes/16-writing-functions.md
+++ b/_episodes/16-writing-functions.md
@@ -6,7 +6,7 @@ questions:
 - "How can I create my own functions?"
 objectives:
 - "Explain and identify the difference between function definition and function call."
-- "Write a function that takes a small, fixed number of arguments and producing a single result."
+- "Write a function that takes a small, fixed number of arguments and produces a single result."
 - "Correctly identify local and global variable use in a function."
 - "Correctly identify portions of source code that will be displayed as online help, and in particular distinguish docstrings from comments."
 - "Write short docstrings for functions."

--- a/_episodes/19-defensive.md
+++ b/_episodes/19-defensive.md
@@ -78,7 +78,7 @@ def average(values):
 ~~~
 def kelvin_to_celsius(k):
     assert k >= 0.0, 'Temperature in Kelvin cannot be negative'
-    return FIXME
+    return k - 273.15
 ~~~
 {: .python}
 

--- a/_episodes/21-next-steps.md
+++ b/_episodes/21-next-steps.md
@@ -22,7 +22,7 @@ keypoints:
 
 *   Stack Overflow's [general Python section](http://stackoverflow.com/questions/tagged/python)
     can be helpful,
-    as can the sections on[NumPy](http://stackoverflow.com/questions/tagged/numpy),
+    as can the sections on [NumPy](http://stackoverflow.com/questions/tagged/numpy),
     [SciPy](http://stackoverflow.com/questions/tagged/scipy),
     [Pandas](http://stackoverflow.com/questions/tagged/pandas),
     and other topics.


### PR DESCRIPTION
Fixed a couple of typos. The `3.0` to `3.54` change is important.
The `FIXME` in the `kelvin_to_celsius` function was replaced by the actual calculation.
I kept each fix in a single commit so you can cherry pick but I can also stash them if desired.