### PR TITLE
Fixing various warnings produced by 'make lesson-check-all'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ python-novice-gapminder
 =======================
 
 Introduction to Python for non-programmers with a focus on data analysis.
-Please see <https://swcarpentry.github.io/python-novice-gapminder/> for a rendered version of this material,
+Please see <https://swcarpentry.github.io/python-novice-gapminder/> 
+for a rendered version of this material,
 [the lesson template documentation][lesson-example]
 for instructions on formatting, building, and submitting material,
 or run `make` in this directory for a list of helpful commands.

--- a/_episodes/01-run-quit.md
+++ b/_episodes/01-run-quit.md
@@ -18,15 +18,18 @@ keypoints:
 ---
 ## Python programs are plain text files.
 
-*   They have the ".py" extension to let everyone know (including the operating system) it is a Python program.
+*   They have the ".py" extension to let everyone know (including the operating system) 
+it is a Python program.
 *   It's common to write them using a text editor but we are going to use the Jupyter Notebook.
-*   The bit of extra setup is well worth it because the Notebook provides code completion and other helpful features.
+*   The bit of extra setup is well worth it because the Notebook provides code completion 
+and other helpful features.
 *   Notebook files have the extension ".ipynb" to distinguish them from plain-text Python programs.
 
 ## Use the Jupyter Notebook for editing and running Python.
 
 *   The [Anaconda package manager][anaconda] is an automated way to install the Jupyter notebook.
-    *   See [the setup instructions]({{ site.github.url }}/setup/) for Anaconda installation instructions.
+    *   See [the setup instructions]({{ site.github.url }}/setup/) for Anaconda installation 
+        instructions.
 *   It also installs all the extra libraries it needs to run.
 *   Once you have installed Python and the Jupyter Notebook requirements, open a shell and type:
 
@@ -42,11 +45,16 @@ keypoints:
 *   You can type code into the browser and see the result when the web page talks to the server.
 *   This has several advantages:
 	- You can easily type, edit, and copy and paste blocks of code.
-	- Tab complete allows you to easily access the names of things you are using and learn more about them.
-	- It allows you to annotate your code with links, different sized text, bullets, etc to make it more accessible to you and your collaborators.
-	- It allows you to display figures next to the code that produces them to tell a complete story of the analysis.
-*   The notebook is stored as JSON but can be saved as a .py file if you would like to run it from the bash shell or a python interpreter.
-*   Just like a webpage, the saved notebook looks different to what you see when it gets rendered by your browser.
+	- Tab complete allows you to easily access the names of things you are 
+    using and learn more about them.
+	- It allows you to annotate your code with links, different sized text, bullets, 
+    etc to make it more accessible to you and your collaborators.
+	- It allows you to display figures next to the code that produces them to 
+    tell a complete story of the analysis.
+*   The notebook is stored as JSON but can be saved as a .py file if you would
+    like to run it from the bash shell or a python interpreter.
+*   Just like a webpage, the saved notebook looks different to what you see when 
+    it gets rendered by your browser.
 
 FIXME: diagram
 
@@ -54,7 +62,8 @@ FIXME: diagram
 >
 > *   The notebook file is stored in a format called JSON.
 > *   Just like a webpage, what's saved looks different from what you see in your browser.
-> *   But this format allows Jupyter to mix software (in several languages) with documentation and graphics, all in one file.
+> *   But this format allows Jupyter to mix software (in several languages) with documentation 
+      and graphics, all in one file.
 {: .callout}
 
 ## The Notebook has Control and Edit modes.
@@ -64,40 +73,50 @@ FIXME: diagram
 
 > ## Code vs. Text
 >
-> We often use the term "code" to mean "the source code of software written in a language such as Python".
+> We often use the term "code" to mean "the source code of 
+> software written in a language such as Python". 
 > A "code cell" in a Notebook is a cell that contains software;
 > a "text cell" is one that contains ordinary prose written for human beings.
 {: .callout}
 
-*   If you press "esc" and "return" alternately, you will see the outer border of your code cell change from blue to green.
+*   If you press "esc" and "return" alternately, you will see the outer 
+    border of your code cell change from blue to green.
     *   The difference in colour is subtle.
 *   These are the control (blue) and edit (green) modes of your notebook.
-*   If you use the "esc" and "return" keys to make the surround blue and then press the "H" key, a list of all the shortcut keys will appear.
+*   If you use the "esc" and "return" keys to make the surround blue and 
+    then press the "H" key, a list of all the shortcut keys will appear.
 *   When in control mode (esc/blue),
     *   The "B" key will make a new cell below the currently selected cell.
     *   The "A" key will make one above.
     *   The "X" key will delete the current cell.
-*   There are lots of shortcuts you can try out and most actions can be done with the menus at the top of the page if you forget the shortcuts.
+*   There are lots of shortcuts you can try out and most actions can be 
+    done with the menus at the top of the page if you forget the shortcuts.
 *   If you remember the "esc" and "H" shortcut, you will be able to find out all the rest.
 
 ## Use the keyboard and mouse to select and edit cells.
 
-*   Pressing the "return" key turns the surround green to signify edit mode and you can type into the cell.
+*   Pressing the "return" key turns the surround green to 
+    signify edit mode and you can type into the cell.
 *   Because we want to be able to write many lines of code in a single cell,
     pressing the "return" key when the border is green moves the cursor to the next line in the cell
     just like in a text editor.
 *   We need some other way to tell the Notebook we want to run what's in the cell.
 *   Pressing the "return" key and the "shift" key together will execute the contents of the cell.
-*   Notice that the "return" and "shift" keys on the right of the keyboard are right next to each other.
+*   Notice that the "return" and "shift" keys on the 
+    right of the keyboard are right next to each other.
 
 ## The Notebook will turn Markdown into pretty-printed documentation.
 
 *   Notebooks can also render [Markdown][markdown].
-    *   A simple plain-text format for writing lists, links, and other things that might go into a web page.
+    *   A simple plain-text format for writing lists, links, 
+        and other things that might go into a web page.
     *   Equivalently, a subset of HTML that looks like what you'd send in an old-fashioned email.
-*   Turn the current cell into a Markdown cell by entering the control mode (esc/blue) and press the "M" key.
-*   The `In [ ]:` will disappear to show it is no longer a code cell and you will be able to write in Markdown.
-*   Turn the current cell into a Code cell by entering the control mode (esc/blue) and press the "Y" key.
+*   Turn the current cell into a Markdown cell by entering 
+    the control mode (esc/blue) and press the "M" key.
+*   The `In [ ]:` will disappear to show it is no longer a 
+    code cell and you will be able to write in Markdown.
+*   Turn the current cell into a Code cell by entering the 
+    control mode (esc/blue) and press the "Y" key.
 
 ## Markdown does most of what HTML does.
 

--- a/_episodes/05-error-messages.md
+++ b/_episodes/05-error-messages.md
@@ -110,9 +110,8 @@ NameError: name 'aege' is not defined
 
 FIXME: diagram of where each type of error occurs.
 
-FIXME: this entire episode needs to move later (we can't do IndentationError yet, or talk about the tracebacks until we've written functions).
-
-FIXME: The 'Identifying Item Errors' section can be moved to later. The List data structure is not yet introduced.
+FIXME: this entire episode needs to move later (we can't do IndentationError yet, or 
+talk about the tracebacks until we've written functions).
 
 > ## Reading Error Messages
 >
@@ -173,7 +172,8 @@ FIXME: The 'Identifying Item Errors' section can be moved to later. The List dat
 >    *without* running it.
 > 2. Run the code and read the error message.
 >    What type of `NameError` do you think this is?
->    Is it a string with no quotes, a misspelled variable, or a variable that should have been defined but was not?
+>    Is it a string with no quotes, a misspelled variable, or a 
+>    variable that should have been defined but was not?
 > 3. Fix the error.
 > 4. Repeat steps 2 and 3, until you have fixed all the errors.
 >

--- a/_episodes/06-libraries.md
+++ b/_episodes/06-libraries.md
@@ -45,7 +45,8 @@ cos(pi) is -1.0
 {: .output}
 
 *   Have to refer to each item with the library's name.
-    *   `math.cos(pi)` won't work: the reference to `pi` doesn't somewhow "inherit" the function's reference to `math`.
+    *   `math.cos(pi)` won't work: the reference to `pi` doesn't 
+        somehow "inherit" the function's reference to `math`.
 
 ## Use `help` to find out more about a library's contents.
 

--- a/_episodes/10-reading-tabular.md
+++ b/_episodes/10-reading-tabular.md
@@ -179,7 +179,8 @@ gdpPercap_2007  34435.36744  25185.00911
 
 ## Use `DataFrame.describe` to get summary statistics about data.
 
-DataFrame.describe() gets the summary statistics of only the columns that have numerical data. All other columns are ignored.
+DataFrame.describe() gets the summary statistics of only the columns that have numerical data. 
+All other columns are ignored.
 ~~~
 print(data.describe())
 ~~~

--- a/_episodes/11-data-frames.md
+++ b/_episodes/11-data-frames.md
@@ -272,7 +272,8 @@ max      13450.401510    16361.876470    18965.055510
 > 1.  GDP per capita for all countries in 1982.
 > 2.  GDP per capita for Denmark for all years.
 > 3.  GDP per capita for all countries for years *after* 1985.
-> 4.  GDP per capita for each country in 2007 as a multiple of GDP per capita for that country in 1952.
+> 4.  GDP per capita for each country in 2007 as a multiple of 
+>     GDP per capita for that country in 1952.
 {: .challenge}
 
 > ## Interpretation

--- a/_episodes/13-looping-data-sets.md
+++ b/_episodes/13-looping-data-sets.md
@@ -54,7 +54,8 @@ dtype: float64
     *   `*` meaning "match zero or more characters"
     *   `?` meaning "match exactly one character"
 *   Provided in Python by the `glob` library, which provides a function also called `glob`.
-*   E.g., `glob.glob('*.txt')` matches all files in the current directory whose names end with `.txt`.
+*   E.g., `glob.glob('*.txt')` matches all files in the current directory 
+    whose names end with `.txt`.
 *   Result is a (possibly empty) list of character strings.
 
 ~~~

--- a/_episodes/19-defensive.md
+++ b/_episodes/19-defensive.md
@@ -146,8 +146,9 @@ assert count_leading_zeros([1, 0]) == 0
 >
 > 1. Explain in simple language what `run_starts` function is supposed to do.
 > 2. Fill in the blanks in the function definition so that all of the assertions succeed.
-> 3. For what input(s) could different users reasonably expect this function to return different values?
->    I.e., where could reasonable people still disagree about the function's behavior?
+> 3. For what input(s) could different users reasonably expect this 
+>     function to return different values? I.e., where could reasonable people 
+>     still disagree about the function's behavior?
 > 4. Add one or more assertions to test for each situation identified above.
 >
 > ~~~

--- a/_episodes/20-style.md
+++ b/_episodes/20-style.md
@@ -28,7 +28,8 @@ keypoints:
 *   [numpydoc](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt):
     a standard for API documentation through docstrings used by NumPy, SciPy,
     and many other Python scientific computing pacakges.
-    Adhering to numpydoc helps ensure that users and developers will know how to use your Python package,
+    Adhering to numpydoc helps ensure that users and developers 
+    will know how to use your Python package,
     either for their own analyses or as a component of their own Python packages.
     If you use numpydoc,
     you can also use existing tools such as [Sphinx](http://sphinx-doc.org/)
@@ -187,7 +188,8 @@ average(values)
 
 > ## Finding Neighbors
 >
-> This function is supposed to find the minimum value adjacent to (but not in) a specified location in an array.
+> This function is supposed to find the minimum value adjacent to 
+> (but not in) a specified location in an array.
 > For what inputs does it produce the wrong answer?
 > How can it be repaired?
 >

--- a/_extras/design.md
+++ b/_extras/design.md
@@ -5,17 +5,20 @@ permalink: /design/
 ---
 ## Process Used
 
-This lesson is meant to be used in both [Data Carpentry][dc-website] and [Software Carpentry][swc-website] workshops.
-It's also meant to serve as a worked example in [instructor training][instructor-training] of how to develop a new lesson.
-To that end,
-the outline below was developed using a slimmed-down variant of the "Understanding by Design" process.
-The main sections are:
+This lesson is meant to be used in both [Data Carpentry][dc-website] and 
+[Software Carpentry][swc-website] workshops. It's also meant to serve as 
+a worked example in [instructor training][instructor-training] of how to 
+develop a new lesson. To that end, the outline below was developed using 
+a slimmed-down variant of the "Understanding by Design" process. The 
+main sections are:
 
 1.  Assumptions about audience, time, etc.
-    (The current draft also includes some conclusions and decisions in this section - that should be refactored.)
+    (The current draft also includes some conclusions and decisions in this 
+    section - that should be refactored.)
 
 2.  Desired results:
-    overall goals, summative assessments at half-day granularity, what learners will be able to do, what learners will know.
+    overall goals, summative assessments at half-day granularity, what learners 
+    will be able to do, what learners will know.
 
 3.  Learning plan:
     each episode has a heading that summarizes what will be covered,
@@ -30,7 +33,8 @@ While it looks like a waterfall process, in practice I did this:
 
 3.  Draft the desired results.
 
-4.  Update the learning milestones (still as just one bullet point each, no time estimates or exercises).
+4.  Update the learning milestones (still as just one bullet point each, 
+    no time estimates or exercises).
 
 5.  Get early feedback from four people.
 
@@ -39,24 +43,19 @@ While it looks like a waterfall process, in practice I did this:
 7.  Ask for feedback and start iterating (mostly to cut things).
 
 At the start of #7 above, the lesson needed 8.5 hours, versus a budget of 6.5.
-NumPy went,
-as did everything to do with running scripts from the command line and a bunch of other topics that are useful and important,
-but not *as* important as what's there.
-This was also the point at which I settled on using the Jupyter Notebook
-(I'd decided on the [Gapminder data][gapminder-data] at the outset to be consistent with [Data Carpentry][dc-website]).
-It took about six hours of work over several weeks to get to the point where I felt the lesson was ready for general feedback.
+NumPy went, as did everything to do with running scripts from the command line 
+and a bunch of other topics that are useful and important, but not *as* important 
+as what's there. This was also the point at which I settled on using the Jupyter 
+Notebook (I'd decided on the [Gapminder data][gapminder-data] at the outset to be 
+consistent with [Data Carpentry][dc-website]). It took about six hours of work over 
+several weeks to get to the point where I felt the lesson was ready for general feedback.
 
-I then solicited feedback from half a dozen experienced instructors.
-Based on what they said,
-I made further cuts
-in order to devote more (i.e., more realistic) time to basic topics.
-Defensive programming, debugging, and programming style were merged,
-which freed up another half an hour to spend on functions:
-these are the key to writing reusable programs,
-but defining vs. calling,
-parameter passing,
-variable scope,
-and the call stack all need time.
+I then solicited feedback from half a dozen experienced instructors. Based on what 
+they said, I made further cuts in order to devote more (i.e., more realistic) time 
+to basic topics. Defensive programming, debugging, and programming style were merged,
+which freed up another half an hour to spend on functions: these are the key to writing 
+reusable programs, but defining vs. calling, parameter passing, variable scope, and the 
+call stack all need time.
 
 ## Stage 1 - Assumptions
 
@@ -78,11 +77,13 @@ and the call stack all need time.
     *   Use the Jupyter Notebook
         *   Authentic tool used by many instructors
         *   There isn't really an alternative
-        *   And means that even people who have seen a bit of Python before will probably learn something
+        *   And means that even people who have seen a bit of Python before 
+            will probably learn something
 *   Data
     *   Use the gapminder data throughout
     *   But break into multiple files by continent
-        *   To make display of output from examples tidier (use Australia/New Zealand, which is only two lines)
+        *   To make display of output from examples tidier (use Australia/New Zealand, 
+            which is only two lines)
         *   And allow examples showing use of multiple data sets
 *   Focus on Pandas instead of NumPy
     *   Makes lesson usable by both Data Carpentry and Software Carpentry
@@ -119,8 +120,10 @@ and the call stack all need time.
         6.  Dependencies and requirements are explicit (e.g., a requirements.txt file)
             *   This rule is *not* covered in this lesson
         7.  Commenting/uncommenting are not routinely used to control program behavior
-        8.  Use a simple example or test data set to run to tell if it's working at all and whether it gives a known correct output for a simple known input
-        9.  Submit code to a reputable DOI-issuing repository upon submission of paper, just like data
+        8.  Use a simple example or test data set to run to tell if it's working at all 
+            and whether it gives a known correct output for a simple known input
+        9.  Submit code to a reputable DOI-issuing repository upon submission of paper, 
+            just like data
             *   This rule is *not* covered in this lesson
 2.  Enable them to make sense of other onlines tutorials and resources
 
@@ -170,7 +173,8 @@ How do I...
     *   Modularity for readability as well as re-use
     *   No duplication
     *   Document purpose and use
-*   That there is no magic: the programs they use are no different in principle from those they build
+*   That there is no magic: the programs they use are no different 
+    in principle from those they build
 *   How to assign values to variables
 *   What integers, floats, strings, and data frames are
 *   How to trace the execution of a `for` loop
@@ -196,7 +200,8 @@ but is included for reference.
 *   Variables and Assignment (09:15)
     *   Teaching: 10 min
     *   Exercises: 10 min
-        *   Trace behavior of swapping (`a, b = b, a` the old fashioned way) with an intermediate variable
+        *   Trace behavior of swapping (`a, b = b, a` the old fashioned way) 
+            with an intermediate variable
         *   Calculate elapsed time in seconds using named values for seconds per minute, etc.
 *   Data Types and Type Conversion (09:35)
     *   Teaching: 10 min

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -21,7 +21,8 @@ Don't tell people to Google things.
     (That said, if learners have done enough programming before to be past these issues,
     having them search for solutions online can help them solidify their understanding.)
     It's also worth quoting
-    [Trevor King](https://github.com/swcarpentry/python-novice-gapminder/issues/22#issuecomment-182573516)'s
+    [Trevor King](https://github.com/swcarpentry/python-novice-
+    gapminder/issues/22#issuecomment-182573516)'s
     comment about online search:
     "If you find anything,
     other folks were confused enough to bother with a blog or Stack Overflow post,

--- a/setup.md
+++ b/setup.md
@@ -19,17 +19,19 @@ you are ready to go as soon as the workshop begins.
 
 ### Windows - [Video tutorial](https://www.youtube.com/watch?v=xxQ0mzZ8UvA)
 
-1. Open [http://continuum.io/downloads](http://continuum.io/downloads#_windows) with your web browser.
+1. Open [http://continuum.io/downloads](http://continuum.io/downloads#_windows) 
+    with your web browser.
 
 2. Download the Python 3 installer for Windows.
 
-3. Double-click the executable and install Python 3 using _MOST_ of the 
-   default settings. The only exception is to check the 
-   **Make Anaconda the default Python** option.
+3. Double-click the executable and install Python 3 using _MOST_ of the
+    default settings. The only exception is to check the 
+    **Make Anaconda the default Python** option.
 
 ### Mac OS X - [Video tutorial](https://www.youtube.com/watch?v=TcSAln46u9U)
 
-1. Open [http://continuum.io/downloads](http://continuum.io/downloads#_macosx) with your web browser.
+1. Open [http://continuum.io/downloads](http://continuum.io/downloads#_macosx) 
+    with your web browser.
 
 2. Download the Python 3 installer for OS X.
 
@@ -42,7 +44,7 @@ If you run into any difficulties, please request help before the workshop begins
 1.  Open [http://continuum.io/downloads](http://continuum.io/downloads#_unix) with your web browser.
 
 2.  Download the Python 3 installer for Linux.
-    
+
 3.  Install Python 3 using all of the defaults for installation.
 
     a.  Open a terminal window.
@@ -59,28 +61,32 @@ If you run into any difficulties, please request help before the workshop begins
     and press tab.  The name of the file you just downloaded should appear.
 
     d.  Press enter.
-    
+
     e.  Follow the text-only prompts.  When the license agreement appears (a colon
-        will be present at the bottom of the screen) hold the down arrow until the bottom of the text.
-        Type `yes` and press enter to approve the license. Press enter again to approve the
-        default location for the files. Type `yes` and press enter to prepend Anaconda to
-        your `PATH` (this makes the Anaconda distribution the default Python).
+        will be present at the bottom of the screen) hold the down arrow until the 
+        bottom of the text. Type `yes` and press enter to approve the license. Press 
+        enter again to approve the default location for the files. Type `yes` and 
+        press enter to prepend Anaconda to your `PATH` (this makes the Anaconda 
+        distribution the default Python).
 
 ## Getting the Data
 
 The data we will be using is taken from the [gapminder](http://gapminder.org) dataset.
-To obtain it, download and unzip the file [python-novice-gapminder-data.zip](python-novice-gapminder-data.zip).
-In order to follow the presented material, you should launch a Jupyter notebook in the "data" directory 
-(see [Starting Python](#Starting-Python)).
+To obtain it, download and unzip the file 
+[python-novice-gapminder-data.zip](python-novice-gapminder-data.zip).
+In order to follow the presented material, you should launch a Jupyter 
+notebook in the "data" directory (see [Starting Python](#Starting-Python)).
 
 ## Starting Python
 
-We will teach Python using the [Jupyter notebook](http://jupyter.org/), a programming environment that
-runs in a web browser. Jupyter requires a reasonably up-to-date browser, preferably
-a current version of Chrome, Safari, or Firefox (note that Internet Explorer version 9
-and below are *not* supported). If you installed Python using Anaconda, Jupyter should already
-be on your system. If you did not use Anaconda, use the Python package manager pip.
-([See the Jupyter website for details](http://jupyter.readthedocs.io/en/latest/install.html#optional-for-experienced-python-developers-installing-jupyter-with-pip))
+We will teach Python using the [Jupyter notebook](http://jupyter.org/), a 
+programming environment that runs in a web browser. Jupyter requires a reasonably 
+up-to-date browser, preferably a current version of Chrome, Safari, or Firefox 
+(note that Internet Explorer version 9 and below are *not* supported). If you 
+installed Python using Anaconda, Jupyter should already be on your system. If 
+you did not use Anaconda, use the Python package manager pip.
+([See the Jupyter website for details](http://jupyter.readthedocs.io/en/latest/
+install.html#optional-for-experienced-python-developers-installing-jupyter-with-pip))
 
 To start the notebook, open a terminal or git bash and type the command:
 
@@ -89,7 +95,8 @@ $ jupyter notebook
 ~~~
 {: .source}
 
-To start the Python interpreter without the notebook, open a terminal or git bash and type the command:
+To start the Python interpreter without the notebook, open a terminal 
+or git bash and type the command:
 
 ~~~
 $ python


### PR DESCRIPTION
When running the lesson check previously many warnings were displayed. This commit has various changes the the markdown files to remove all but one of these warnings. This was done as a part of the instructor-training assignment.

Previous warnings:

./README.md: Line(s) are too long: 5
./_episodes/01-run-quit.md: Line(s) are too long: 21, 23, 29, 45, 46, 47, 48, 49, 57, 67, 72, 75, 80, 85, 91, 96, 98, 99, 100
./_episodes/05-error-messages.md: Line(s) are too long: 109, 113, 174
./_episodes/06-libraries.md: Line(s) are too long: 48
./_episodes/11-data-frames.md: Line(s) are too long: 275
./_episodes/13-looping-data-sets.md: Line(s) are too long: 57
./_episodes/19-defensive.md: Line(s) are too long: 149
./_episodes/20-style.md: Line(s) are too long: 31, 190
./_extras/design.md: Line(s) are too long: 8, 9, 11, 15, 18, 33, 43, 46, 47, 81, 85, 122, 123, 173, 199
./_extras/guide.md: Line(s) are too long: 24
./setup.md: Line(s) are too long: 22, 32, 64, 72, 73, 78, 83, 92
./setup.md: Line(s) end with whitespace: 45, 62


Current warning:

./_episodes/05-error-messages.md: Line(s) are too long: 109

The unfixed warning is a heading that is too long that I wasn't sure how to make it span multiple lines.