### PR TITLE
all cases of "data frame" (with space) moved to "dataframe" (without space)

### DIFF
--- a/_episodes/07-reading-tabular.md
+++ b/_episodes/07-reading-tabular.md
@@ -1,5 +1,5 @@
 ---
-title: "Reading Tabular Data into Data Frames"
+title: "Reading Tabular Data into DataFrames"
 teaching: 10
 exercises: 10
 questions:
@@ -7,19 +7,19 @@ questions:
 objectives:
 - "Import the Pandas library."
 - "Use Pandas to load a simple CSV data set."
-- "Get some basic information about a Pandas Data frame."
+- "Get some basic information about a Pandas DataFrame."
 keypoints:
 - "Use the Pandas library to do statistics on tabular data."
 - "Use `index_col` to specify that a column's values should be used as row headings."
-- "Use `DataFrame.info` to find out more about a data frame."
-- "The `DataFrame.columns` variable stores information about the data frame's columns."
-- "Use `DataFrame.T` to transpose a data frame."
+- "Use `DataFrame.info` to find out more about a dataframe."
+- "The `DataFrame.columns` variable stores information about the dataframe's columns."
+- "Use `DataFrame.T` to transpose a dataframe."
 - "Use `DataFrame.describe` to get summary statistics about data."
 ---
 ## Use the Pandas library to do statistics on tabular data.
 
 *   Pandas is a widely-used Python library for statistics, particularly on tabular data.
-    *   Borrows many features from R's data frames.
+    *   Borrows many features from R's dataframes.
 *   Load it with `import pandas`.
 *   Read a Comma Separate Values (CSV) data file with `pandas.read_csv`.
     *   Argument is the name of the file to be read.
@@ -51,7 +51,7 @@ print(data)
 ~~~
 {: .output}
 
-*   The columns in a data frame are the observed variables, and the rows are the observations.
+*   The columns in a dataframe are the observed variables, and the rows are the observations.
 *   Pandas uses backslash `\` to show wrapped lines when output is too wide to fit the screen.
 
 > ## File Not Found
@@ -98,7 +98,7 @@ New Zealand     18363.32494     21050.41377     23189.80135     25185.00911
 ~~~
 {: .output}
 
-## Use `DataFrame.info` to find out more about a data frame.
+## Use `DataFrame.info` to find out more about a dataframe.
 
 ~~~
 data.info()
@@ -131,7 +131,7 @@ memory usage: 208.0+ bytes
     *   We will talk later about null values, which are used to represent missing observations.
 *   Uses 208 bytes of memory.
 
-## The `DataFrame.columns` variable stores information about the data frame's columns.
+## The `DataFrame.columns` variable stores information about the dataframe's columns.
 
 *   Note that this is data, *not* a method.
     *   Like `math.pi`.
@@ -150,7 +150,7 @@ Index(['gdpPercap_1952', 'gdpPercap_1957', 'gdpPercap_1962', 'gdpPercap_1967',
 ~~~
 {: .output}
 
-## Use `DataFrame.T` to transpose a data frame.
+## Use `DataFrame.T` to transpose a dataframe.
 
 *   Sometimes want to treat columns as rows and vice versa.
 *   Transpose (written `.T`) doesn't copy the data, just changes the program's view of it.
@@ -262,8 +262,8 @@ max      23424.766830    26997.936570    30687.754730    34435.367440
 > ## Writing Data
 > 
 > As well as the `read_csv` function for reading data from a file,
-> Pandas provides a `to_csv` function to write data frames to files.
+> Pandas provides a `to_csv` function to write dataframes to files.
 > Applying what you've learned about reading from files,
-> write one of your data frames to a file called `processed.csv`.
+> write one of your dataframes to a file called `processed.csv`.
 > You can use `help` to get information on how to use `to_csv`.
 {: .challenge}

--- a/_episodes/08-data-frames.md
+++ b/_episodes/08-data-frames.md
@@ -170,7 +170,7 @@ Poland               False          False          False
 
 ## Select values or NaN using a Boolean mask.
 
-*   Aframe full of Booleans is sometimes called a *mask* because of how it can be used.
+*   A frame full of Booleans is sometimes called a *mask* because of how it can be used.
 
 ~~~
 mask = subset > 10000

--- a/_episodes/08-data-frames.md
+++ b/_episodes/08-data-frames.md
@@ -1,14 +1,14 @@
 ---
-title: "Pandas Data Frames"
+title: "Pandas DataFrames"
 teaching: 15
 exercises: 15
 questions:
 - "How can I do statistical analysis of tabular data?"
 objectives:
-- "Select individual values from a Pandas data frame."
-- "Select entire rows or entire columns from a data frame."
-- "Select a subset of both rows and columns from a data frame in a single operation."
-- "Select a subset of a data frame by a single Boolean criterion."
+- "Select individual values from a Pandas dataframe."
+- "Select entire rows or entire columns from a dataframe."
+- "Select a subset of both rows and columns from a dataframe in a single operation."
+- "Select a subset of a dataframe by a single Boolean criterion."
 keypoints:
 - "Use `DataFrame.ix[..., ...]` to select values by location."
 - "Use `:` on its own to mean all columns or all rows."
@@ -106,7 +106,7 @@ pythonic behavior.
 ## Result of slicing can be used in further operations.
 
 *   Usually don't just print a slice.
-*   All the statistical operators that work on entire data frames
+*   All the statistical operators that work on entire dataframes
     work the same way on slices.
 
 ~~~
@@ -136,7 +136,7 @@ dtype: float64
 ## Use comparisons to select data based on value.
 
 *   Comparison is applied element by element.
-*   Returns a similarly-shaped data frame of `True` and `False`.
+*   Returns a similarly-shaped dataframe of `True` and `False`.
 
 ~~~
 # Use a subset of data to keep output readable.
@@ -170,7 +170,7 @@ Poland               False          False          False
 
 ## Select values or NaN using a Boolean mask.
 
-*   A frame full of Booleans is sometimes called a *mask* because of how it can be used.
+*   Aframe full of Booleans is sometimes called a *mask* because of how it can be used.
 
 ~~~
 mask = subset > 10000

--- a/_episodes/09-plotting.md
+++ b/_episodes/09-plotting.md
@@ -9,7 +9,7 @@ objectives:
 - "Create a scatter plot showing relationship between two data sets."
 keypoints:
 - "`matplotlib` is the most widely used scientific plotting library in Python."
-- "Plot data directly from a Pandas data frame."
+- "Plot data directly from a Pandas dataframe."
 - "Select and transform data, then plot it."
 - "Many styles of plot are available."
 - "Can plot many sets of data together."
@@ -37,9 +37,9 @@ plt.ylabel('Doubles')
 ~~~
 {: .python}
 
-## Plot data directly from a Pandas data frame.
+## Plot data directly from a Pandas dataframe.
 
-*   We can also plot Pandas data frames.
+*   We can also plot Pandas dataframes.
 *   This implicitly uses `matplotlib.pyplot`.
 
 ~~~
@@ -77,7 +77,7 @@ plt.ylabel('GDP per capita')
 
 *   Extract years from the last four characters of the columns' names.
     *   Store these in a list using the Accumulator pattern.
-*   Can also convert data frame data to a list.
+*   Can also convert dataframe data to a list.
 
 ~~~
 # Accumulator pattern to collect years (as character strings).

--- a/_episodes/17-conditionals.md
+++ b/_episodes/17-conditionals.md
@@ -364,7 +364,7 @@ final velocity: 30.0
 >
 > That function would typically be used within a `for` loop, but Pandas has
 > a different, more efficient way of doing the same thing, and that is by
-> *applying* a function to a data frame or a portion of a data frame.  Here
+> *applying* a function to a dataframe or a portion of a dataframe.  Here
 > is an example, using the definition above.
 >
 > ~~~
@@ -375,7 +375,7 @@ final velocity: 30.0
 >
 > There is a lot in that second line, so let's take it piece by piece.
 > On the right side of the `=` we start with `data['lifeExp']`, which is the
-> column in the data frame called `data` labeled `lifExp`.  We use the
+> column in the dataframe called `data` labeled `lifExp`.  We use the
 > `apply()` to do what it says, apply the `calculate_life_quartile` to the
-> value of this column for every row in the data frame.
+> value of this column for every row in the dataframe.
 {: .callout}

--- a/_extras/design.md
+++ b/_extras/design.md
@@ -121,12 +121,12 @@ I know...
 *   ...that there is no magic: the programs they use are no different 
     in principle from those they build
 *   ...how to assign values to variables
-*   ...what integers, floats, strings, NumPy arrays, and Pandas data frames are
+*   ...what integers, floats, strings, NumPy arrays, and Pandas dataframes are
 *   ...how to trace the execution of a `for` loop
 *   ...how to trace the execution of `if`/`else` statements
 *   ...how to create and index lists
 *   ...how to create and index NumPy arrays
-*   ...how to create and index Pandas data frames
+*   ...how to create and index Pandas dataframes
 *   ...how to create time series plots
 *   ...the difference between defining and calling a function
 *   ...where to find documentation on standard libraries
@@ -137,7 +137,7 @@ I know...
 ### Summative Assessment
 
 *   Midpoint: create time-series plot for each file in a directory.
-*   Final: extract data from Pandas data frame
+*   Final: extract data from Pandas dataframe
     and create comparative multi-line time series plot.
 
 ### [Running and Quitting Interactively]({{page.root}}/01-run-quit/) (9:00)
@@ -216,20 +216,20 @@ I know...
 *   Teaching: 10 min
     *   Import the Pandas library.
     *   Use Pandas to load a simple CSV data set.
-    *   Get some basic information about a Pandas Data frame.
+    *   Get some basic information about a Pandas DataFrame.
 *   Challenges: 10 min
     *   Read the data for the Americas and display its summary statistics.
     *   What do `.head` and `.tail` do?
     *   What string(s) should you pass to `read_csv` to read files from other directories?
     *   How can you *write* CSV data?
 
-### [Data Frames]({{page.root}}/08-data-frames/) (11:15)
+### [DataFrames]({{page.root}}/08-data-frames/) (11:15)
 
 *   Teaching: 15 min
-    *   Select individual values from a Pandas data frame.
-    *   Select entire rows or entire columns from a data frame.
-    *   Select a subset of both rows and columns from a data frame in a single operation.
-    *   Select a subset of a data frame by a single Boolean criterion.
+    *   Select individual values from a Pandas dataframe.
+    *   Select entire rows or entire columns from a dataframe.
+    *   Select a subset of both rows and columns from a dataframe in a single operation.
+    *   Select a subset of a dataframe by a single Boolean criterion.
 *   Challenges: 15 min
     *   What expression will find the Per Capita GDP of Serbia in 2007?
     *   What rule governs what is (or isn't) included in numerical and named slices in Pandas?


### PR DESCRIPTION
The Pandas Python library uses the term "dataframe" without a space rather than "data frame".  For example, see the Pandas documentation describing a dataframe [here](http://pandas.pydata.org/pandas-docs/stable/dsintro.html#dataframe).  This commit changes all instances of "data frame" (including camelcase versions) to their matching case without the middle space.