### PR TITLE
pandas.load_csv() typo in Episode 8 exercise

### DIFF
--- a/_episodes/08-data-frames.md
+++ b/_episodes/08-data-frames.md
@@ -258,7 +258,7 @@ max      13450.401510    16361.876470    18965.055510
 > When would you use these methods?
 >
 > ~~~
-> data = pandas.load_csv('data/gapminder_gdp_europe.csv', index_col='country')
+> data = pandas.read_csv('data/gapminder_gdp_europe.csv', index_col='country')
 > print(data.idxmin())
 > print(data.idxmax())
 > ~~~


### PR DESCRIPTION
In the "Selecting Indices" exercise from Episode 8 `pandas.load_csv()` appears to be a typo for `pandas.read_csv()`
