### PR TITLE
Add instructions for sublists

### DIFF
--- a/_episodes/01-run-quit.md
+++ b/_episodes/01-run-quit.md
@@ -154,6 +154,27 @@ FIXME: diagram
 <div class="row">
   <div class="col-md-6" markdown="1">
 ~~~
+*  You can use indents
+	*  To create sublists 
+	*  of the same type
+*  Or sublists
+	1. Of different
+	1. types
+~~~
+{: .python}
+  </div>
+  <div class="col-md-6" markdown="1">
+*  You can use indents
+	*  To create sublists of the same type
+*  Or sublists
+	1. Of different
+	1. types
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6" markdown="1">
+~~~
 # A Level-1 Heading
 ~~~
 {: .python}


### PR DESCRIPTION
This is part of the checkout process for Jake Szamosi. Adding instructions for using indents to create sublists in Markdown.