### PR TITLE
remove non-working example

### DIFF
--- a/_episodes/08-data-frames.md
+++ b/_episodes/08-data-frames.md
@@ -237,21 +237,6 @@ max      13450.401510    16361.876470    18965.055510
 > {: .python}
 {: .challenge}
 
-> ## Reconstructing Data
->
-> Explain what each line in the following short program does:
-> what is in `first`, `second`, etc.?
->
-> ~~~
-> first = pandas.read_csv('data/gapminder_gdp_all.csv', index_col='country')
-> second = df[df['continent'] == 'Americas']
-> third = second.drop('Puerto Rico')
-> fourth = third.drop('continent', axis = 1)
-> fourth.to_csv('result.csv')
-> ~~~
-> {: .python}
-{: .challenge}
-
 > ## Selecting Indices
 >
 > Explain in simple terms what `idxmin` and `idxmax` do in the short program below.


### PR DESCRIPTION
The example I propose removing uses the df[ ] operator.  Based on the code introduced by lesson 08, I don't think it works.  Specifically, after running: 
import pandas
path="python-novice-gapminder-data/data/gapminder_all.csv"
first = pandas.read_csv(path, index_col='country')
first.head()
# then the following fails, 
second = df[df['continent'] == 'Americas']
# with the error:
NameError                                 Traceback (most recent call last)
<ipython-input-68-460e46bc0b3f> in <module>()
----> 1 second = df[df['continent'] == 'Americas']
      2 second.head()

NameError: name 'df' is not defined

Is there an additional import statement that's missing?