### PR TITLE
add docker + docker-compose Jekyll setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git
 *.pyc
 *~
 .DS_Store
@@ -5,4 +6,3 @@
 .sass-cache
 __pycache__
 _site
-.jekyll-metadata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM jekyll/jekyll:pages
+
+RUN apk add -q --no-cache python3 make
+COPY . /srv/jekyll
+RUN chmod -R a+rX,g+rwX /srv/jekyll && chown -R jekyll: /srv/jekyll

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jekyll/jekyll:pages
+FROM jekyll/jekyll:3
 
 RUN apk add -q --no-cache python3 make
 COPY . /srv/jekyll

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ for a rendered version of this material,
 for instructions on formatting, building, and submitting material,
 or run `make` in this directory for a list of helpful commands.
 
+## Run Jekyll in a Docker container
+
+If you download and install the latest versions of [Docker compose](https://docs.docker.com/compose/install/) and
+[Docker engine](https://docs.docker.com/engine/installation/) you can build a Jekyll container to serve this site with
+hot-reloading and incremental rebuilds by running `docker-compose up` and visiting `localhost:4000` in a browser. 
+
+The docker-compose file mounts this root directory into the Jekyll container so you can edit the lesson's Markdown files
+in place and see those changes when you refresh your browser window.
+
+To clean up and remove the docker containers, run `docker-compose down -v` or `docker system prune`.
+
 Maintainer(s):
 
 * [Bennet Fauber][fauber-bennet]

--- a/README.md
+++ b/README.md
@@ -8,16 +8,26 @@ for a rendered version of this material,
 for instructions on formatting, building, and submitting material,
 or run `make` in this directory for a list of helpful commands.
 
-## Run Jekyll in a Docker container
+## Run Jekyll and serve lesson content in a Docker container
 
 If you download and install the latest versions of [Docker compose](https://docs.docker.com/compose/install/) and
-[Docker engine](https://docs.docker.com/engine/installation/) you can build a Jekyll container to serve this site with
-hot-reloading and incremental rebuilds by running `docker-compose up` and visiting `localhost:4000` in a browser. 
+[Docker engine](https://docs.docker.com/engine/installation/) you can run a Jekyll container that serves this site
+with hot-reloading and incremental rebuilds by executing `% docker-compose up` from the command line. On Windows you
+should run this via [`PowerShell`](https://docs.docker.com/docker-for-windows/), not a cygwin / bash shell.
 
-The docker-compose file mounts this root directory into the Jekyll container so you can edit the lesson's Markdown files
-in place and see those changes when you refresh your browser window.
+The docker-compose file mounts the cloned repository's root directory into the Jekyll container so you should be able to
+edit this lesson's Markdown files in place and see those changes when you refresh your browser window.
 
-To clean up and remove the docker containers, run `docker-compose down -v` or `docker system prune`.
+This should work without issue on up-to-date Linux and Mac OS systems but Windows requires some additional
+configuration.
+
+### Windows Docker configuration
+[Explicitly mark the hard drive where this git repository was cloned as a shared drive with Docker](https://blogs.msdn.microsoft.com/stevelasker/2016/06/14/configuring-docker-for-windows-volumes/)
+
+The site will be accessible at `localhost:4000` from any browser. 
+
+### Clean up
+To clean up and remove the docker containers, run `docker-compose down`.
 
 Maintainer(s):
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  web:
+    build: ./
+    image: swcarpentry/python-novice-gapminder:latest
+    command: ['jekyll', 'serve', '-I'] # serve with incremental rebuilds
+    volumes:
+      - .:/srv/jekyll
+    ports:
+      - "127.0.0.1:4000:4000" # only allow traffic from localhost
+      # - "4000:4000" # uncomment this for external access


### PR DESCRIPTION
Using [jekyll/jekyll:pages](https://hub.docker.com/r/jekyll/jekyll/) as
a base image for "as close to Github pages as possible" compliance. See
https://github.com/jekyll/docker/wiki for more details.

This was built with docker-compose version 1.11.2 and
docker version 17.03.1-ce

resolves issue #120