### PR TITLE
Update wording in 17-conditionals.md

### DIFF
--- a/_episodes/17-conditionals.md
+++ b/_episodes/17-conditionals.md
@@ -58,7 +58,7 @@ for m in masses:
 
 ## Use `else` to execute a block of code when an `if` condition is *not* true.
 
-*   `else` is always attached to `if`.
+*   `else` can be used following an `if`.
 *   Allows us to specify an alternative to execute when the `if` *branch* isn't taken.
 
 ~~~


### PR DESCRIPTION
Soften the wording regarding the else statement.

This is a pedantic change, but the else statement is not always attached to an if statement. It can for example be used in a try/except clause:

https://docs.python.org/3/tutorial/errors.html
```
for arg in sys.argv[1:]:
    try:
        f = open(arg, 'r')
    except OSError:
        print('cannot open', arg)
    else:
        print(arg, 'has', len(f.readlines()), 'lines')
        f.close()
```
