### PR TITLE
fixed faulty "Practice accumulating" problem set

### DIFF
--- a/_episodes/12-for-loops.md
+++ b/_episodes/12-for-loops.md
@@ -228,7 +228,7 @@ print(total)
 > # List of word lengths: ["red", "green", "blue"] => [3, 5, 4]
 > lengths = ____
 > for word in ["red", "green", "blue"]:
->     lengths = lengths.____(____)
+>     lengths.____(____)
 > print(lengths)
 > ~~~
 > {: .python}


### PR DESCRIPTION
Hi folks,

The only function the students have been taught that accumulates values in a list is `append()`, but it does not return a value, so the line:
```
> # List of word lengths: ["red", "green", "blue"] => [3, 5, 4]
> lengths = ____
> for word in ["red", "green", "blue"]:
>     lengths  = lengths.____(____)
> print(lengths)
> ~~~
```
will fail.  This can be done by using the `__add__()` function, but I'm pretty sure this isn't what the problem set designers had in mind.

