### PR TITLE
Fix typo

### DIFF
--- a/_episodes/01-run-quit.md
+++ b/_episodes/01-run-quit.md
@@ -322,7 +322,7 @@ Or use [named links][data_carpentry].
 > 
 > > ## Solution
 > >
-> > The python code gets treated like markdown text.
+> > The Python code gets treated like markdown text.
 > > The lines appear as if they are part of one contiguous paragraph.
 > > This could be useful to temporarly turn on and off cells in notebooks that get used for multiple purposes. 
 > > ~~~

--- a/_episodes/08-data-frames.md
+++ b/_episodes/08-data-frames.md
@@ -98,7 +98,7 @@ Poland          5338.752143     6557.152776     8006.506993
 {: .output}
 
 In the above code, we discover that **slicing using indexes is inclusive at both
-ends**, which differs from typical python behavior, where slicing indicates
+ends**, which differs from typical Python behavior, where slicing indicates
 everything up to but not including the final index.  However, if we use integers
 when our DataFrame is indexed by something else, slicing follows typical
 pythonic behavior.

--- a/_episodes/15-scope.md
+++ b/_episodes/15-scope.md
@@ -85,7 +85,7 @@ NameError: name 'temperature' is not defined
 > ~~~
 > def another_function
 >   print("Syntax errors are annoying.")
->    print("But at least python tells us about them!")
+>    print("But at least Python tells us about them!")
 >   print("So they are usually not too hard to fix.")
 > ~~~
 > {: .python}


### PR DESCRIPTION
Replace python with Python

I used

~~~
$ cd _episodes
$ for i in *; do sed -i "s/ python / Python /g" $i; done
~~~