### PR TITLE
Update E03: warn about `/` operator between integers in python2.

### DIFF
--- a/_episodes/03-types-conversion.md
+++ b/_episodes/03-types-conversion.md
@@ -282,6 +282,17 @@ first is 2 and second is 5
 > ~~~
 > {: .output}
 >
+> However in Python2 (and other languages), the `/` operator between two integer types perform a floor (`//`) division. To perform a float division, we have to convert one of the integers to float.
+>
+> ~~~
+> print('5 // 3:', 1)
+> print('5 / 3:', 1 )
+> print('5 / float(3):', 1.6666667 )
+> print('float(5) / 3:', 1.6666667 )
+> print('float(5 / 3):', 1.0 )
+> print('5 % 3:', 2)
+> ~~~
+>
 > If `num_subjects` is the number of subjects taking part in a study,
 > and `num_per_survey` is the number that can take part in a single survey,
 > write an expression that calculates the number of surveys needed


### PR DESCRIPTION
I think is it worth warning about it, even if the teacher may choose to skip it.

Also some people might not be aware of running python2 interpreter, and
this can be confusing.
