### PR TITLE
E01: Change Control mode for Command mode.

### DIFF
--- a/_episodes/01-run-quit.md
+++ b/_episodes/01-run-quit.md
@@ -11,7 +11,7 @@ objectives:
 keypoints:
 - "Python programs are plain text files."
 - "Use the Jupyter Notebook for editing and running Python."
-- "The Notebook has Control and Edit modes."
+- "The Notebook has Command and Edit modes."
 - "Use the keyboard and mouse to select and edit cells."
 - "The Notebook will turn Markdown into pretty-printed documentation."
 - "Markdown does most of what HTML does."
@@ -65,7 +65,7 @@ keypoints:
       and graphics, all in one file.
 {: .callout}
 
-## The Notebook has Control and Edit modes.
+## The Notebook has Command and Edit modes.
 
 *   Open a new notebook from the dropdown menu in the top right corner of the file browser page.
 *   Each notebook contains one or more cells that contain code, text, or images.
@@ -84,7 +84,7 @@ keypoints:
 *   These are the control (gray) and edit (green) modes of your notebook.
 *   In control mode, pressing the "H" key will provide 
     a list of all the shortcut keys.
-*   Control mode alows you to edit notebook-level features, and edit mode changes the content of cells.
+*   Command mode alows you to edit notebook-level features, and edit mode changes the content of cells.
 *   When in control mode (esc/gray),
     *   The "B" key will make a new cell below the currently selected cell.
     *   The "A" key will make one above.
@@ -93,7 +93,7 @@ keypoints:
     but there are lots of keyboard shortcuts to speed things up.
 *   If you remember the "esc" and "H" shortcut, you will be able to find out all the rest.
 
-> ## Control Vs. Edit
+> ## Command Vs. Edit
 >
 > In the Jupyter notebook page are you currently in control or edit mode?  
 > Switch between the modes. 
@@ -102,7 +102,7 @@ keypoints:
 >
 > > ## Solution
 > >
-> > Control mode has a grey boarder and Edit mode has a green border
+> > Command mode has a grey boarder and Edit mode has a green border
 > > Use "esc" and "Enter" to switch between modes
 > > You need to be in control mode (Hit "esc" if your cell is green).  Type "B" or "A".
 > > You need to be in control mode (Hit "esc" if your cell is green).  Type "X".


### PR DESCRIPTION
When typing H in Command mode in jupyter version 4.3, the two columns
refer to:
Command Mode and Edit Mode

It could be confusing name it Control here.
![python_gapminder1](https://user-images.githubusercontent.com/3021667/28246700-0116e1b2-6a74-11e7-8124-c12cd862425f.png)

