### PR TITLE
Clarify 04-built-in:Spot the difference exercise

### DIFF
--- a/_episodes/04-built-in.md
+++ b/_episodes/04-built-in.md
@@ -241,6 +241,8 @@ result of print is None
 >    If it runs, does its result make any sense?
 >
 > ~~~
+> easy_string = "abc"
+> print(max(easy_string))
 > rich = "gold"
 > poor = "tin"
 > print(max(rich, poor))

--- a/_episodes/04-built-in.md
+++ b/_episodes/04-built-in.md
@@ -249,6 +249,10 @@ result of print is None
 > print(max(len(rich), len(poor)))
 > ~~~
 > {: .python}
+> > ## Solution
+> >
+> > `max` arguments can be either values separated by `,`, or iterable types like the `str` type. In this case python compares the characters that compose the variable `easy_string`, ordering them lexicographically, and returning the `max` character.
+> {: .solution}
 {: .challenge}
 
 > ## Why Not?


### PR DESCRIPTION
Add easy_string to clarify that max works on iterables.
When the iterable is a string, python orders the characters in
lexicographical order.
