### PR TITLE
removed byte order mark (BOM) from start of file

### DIFF
--- a/_episodes/13-looping-data-sets.md
+++ b/_episodes/13-looping-data-sets.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Looping Over Data Sets"
 teaching: 5
 exercises: 10


### PR DESCRIPTION
fixes https://github.com/swcarpentry/python-novice-gapminder/issues/218

Looks like the file was created using Notepad or similar editor that saves a BOM at start of the file... which presumably messes with the jekyll parser so that it doesn't see the first three characters as being '---' as required for front matter