### PR TITLE
Alternate solution to Division Types challenge

### DIFF
--- a/_episodes/03-types-conversion.md
+++ b/_episodes/03-types-conversion.md
@@ -288,22 +288,24 @@ first is 2 and second is 5
 > to reach everyone once.
 >
 > > ## Solution
-> > Depending on requirements it might be important to detect when the number of subjects per survey doesn't divide the
-> > number of subjects evenly. Detect it with the `%` operator and test if the remainder that it returns is greater than
-> > 0.
-> > 
+> > We want the minimum number of surveys that reaches everyone once, which is
+> > the ceiling of `num_subjects / num_per_survey`. Recalling the mathematical
+> > relationship between ceiling and floor:
 > >
+> > &rceil;x&lceil; = -&lfloor;-x&rfloor;
+> >
+> > we can calculate the number of surveys required using the `//` floor
+> > division operator:
 > > ~~~
 > > num_subjects = 600
 > > num_per_survey = 42
-> > num_surveys = num_subjects // num_per_survey
-> > remainder = num_subjects % num_per_survey
+> > num_surveys = -(-num_subjects // num_per_survey)
 > >
 > > print(num_subjects, 'subjects,', num_per_survey, 'per survey:', num_surveys)
 > > ~~~
 > > {: .python}
 > > ~~~
-> > 600 subjects, 42 per survey: 14
+> > 600 subjects, 42 per survey: 15
 > > ~~~
 > > {: .output}
 > {: .solution}


### PR DESCRIPTION
This is a PR for instructor training checkout.

I suggest this is a better solution to the challenge in that it actually gives the correct answer to the question posed, with the additional merit of using only Python constructs that have been introduced at this point in the lesson. For the values given in the original solution, the correct answer is 15 surveys to reach everyone once, not 14.
The original solution only works when num_per_survey exactly divides num_subjects, and although there is acknowledgement of this limitation in the suggestion to calculate the remainder and test if it's non-zero, this is not implemented in the solution and indeed conditionals are not introduced until much later in episode 17.
A possible objection to my solution is that it requires mathematical knowledge about the relationship between floor and ceiling; my response is that learners who didn't know that before their SWC lesson, learned a new math fact for free!