### PR TITLE
Fix formatting of several solutions

### DIFF
--- a/_episodes/08-data-frames.md
+++ b/_episodes/08-data-frames.md
@@ -505,6 +505,7 @@ data.groupby(wealth_score).sum()
 > > data['gdpPercap_2007']/data['gdpPercap_1952']
 > > ~~~
 > > {: .python}
+> {: .solution}
 {: .challenge}
 
 > ## Interpretation

--- a/_episodes/12-for-loops.md
+++ b/_episodes/12-for-loops.md
@@ -198,6 +198,7 @@ print(total)
 > ~~~
 > {: .python}
 > > ## Solution
+> > 
 > > | Line no | Variables            |
 > > |---------|----------------------|
 > > | 1       | total = 0            |
@@ -207,7 +208,7 @@ print(total)
 > > | 3       | total = 2 char = 'i' |
 > > | 2       | total = 2 char = 'n' |
 > > | 3       | total = 3 char = 'n' |
-> {. solution}
+> {: .solution}
 {: .challenge}
 
 > ## Reversing a String

--- a/_episodes/14-writing-functions.md
+++ b/_episodes/14-writing-functions.md
@@ -182,7 +182,7 @@ result of call is: None
 > > print("calling")
 > > report(22.5)
 > > ~~~
-<{: .solution}
+> {: .solution}
 {: .challenge}
 
 


### PR DESCRIPTION
Some exercise solutions (in episodes 08, 12 and 14) were not being
formatted as solutions correctly, due to various typos in the closing
solution tag. Additionally the table in the solution in episode 12
needed a preceding empty line to be formatted as a table.
