### PR TITLE
update to include new maintainer names

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ or run `make` in this directory for a list of helpful commands.
 
 Maintainer(s):
 
-* [Bennet Fauber][fauber-bennet]
-* [Greg Wilson][wilson-greg]
+* [Allen Lee][lee-allen]
+* [Nathan Moore][moore-nathan]
+* [Sourav Singh][singh-sourav]
 
-[fauber-bennet]: http://software-carpentry.org/team/#fauber_bennet
+[lee-allen]:
 [lesson-example]: https://swcarpentry.github.com/lesson-example/
-[wilson-greg]: http://software-carpentry.org/team/#wilson_g
+[moore-nathan]: https://software-carpentry.org/team/#moore_nathan
+[singh-sourav]:


### PR DESCRIPTION
Hi @alee @souravsingh , 

It seems to be tradition that the maintainers have a link to their page in the "Our Team" page, here: https://software-carpentry.org/team/ 

I didn't see either of you on this list.  This used to be part of onboarding - @ErinBecker would probably know the status of these updates.  Please review and approve if/when you know about this status.