### PR TITLE
make glob more specific

### DIFF
--- a/_episodes/13-looping-data-sets.md
+++ b/_episodes/13-looping-data-sets.md
@@ -87,7 +87,7 @@ all PDB files: []
     so that simple patterns will find the right data.
 
 ~~~
-for filename in glob.glob('data/*.csv'):
+for filename in glob.glob('data/gapminder_*.csv'):
     data = pandas.read_csv(filename)
     print(filename, data['gdpPercap_1952'].min())
 ~~~


### PR DESCRIPTION
- limit glob pattern to gapminder CSVs with a gdpPercap_1952 field
- fixes #131