### PR TITLE
Add note on Jekyll requirement to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ for a rendered version of this material,
 for instructions on formatting, building, and submitting material,
 or run `make` in this directory for a list of helpful commands.
 
+To run the local development server or build the files a local installation of
+[Jekyll](https://jekyllrb.com/) is needed. See the
+[Jekyll installation documentation](https://jekyllrb.com/docs/installation/)
+for detailed instructions.
+
 Maintainer(s):
 
 * [Allen Lee][lee-allen]


### PR DESCRIPTION
This adds a short note on the Jekyll requirement to the Readme -- I was happy to see a Makefile but ran into into an error when running `make site`

```
jekyll build
Configuration file: /home/robert/Desktop/python-novice-gapminder/_config.yml
            Source: /home/robert/Desktop/python-novice-gapminder
       Destination: /home/robert/Desktop/python-novice-gapminder/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
  Liquid Exception: Liquid syntax error (line 30): Unknown tag 'link' in _includes/navbar.html, included in _layouts/base.html
jekyll 3.1.3 | Error:  Liquid syntax error (line 30): Unknown tag 'link'
```

Updating to Jekyll 3.7 fixed this for me, but having the Jekyll requirement mentioned explicitly might be helpful for others.