### PR TITLE
Fixed typo in "Trimming Values" exercise

### DIFF
--- a/_episodes/17-conditionals.md
+++ b/_episodes/17-conditionals.md
@@ -277,7 +277,7 @@ final velocity: 30.0
 >
 > Fill in the blanks so that this program creates a new list
 > containing zeroes where the original list's values were negative
-> and ones where the origina list's values were positive.
+> and ones where the original list's values were positive.
 >
 > ~~~
 > original = [-1.5, 0.2, 0.4, 0.0, -1.3, 0.4]


### PR DESCRIPTION
Changed "...ones where the origina list's values were positive." to ""...ones where the original list's values were positive."

