### PR TITLE
include maintainers in this citation?

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -3,4 +3,4 @@ Please cite this lesson as:
 Allen Lee, Nathan Moore, Sourav Singh, Olav Vahtras
 Software Carpentry: Plotting and Programming in Python.
 http://github.com/swcarpentry/python-novice-plotting,
-2016.
+2018.

--- a/CITATION
+++ b/CITATION
@@ -1,5 +1,6 @@
 Please cite this lesson as:
 
+Allen Lee, Nathan Moore, Sourav Singh, Olav Vahtras
 Software Carpentry: Plotting and Programming in Python.
 http://github.com/swcarpentry/python-novice-plotting,
 2016.


### PR DESCRIPTION
I believe the citation should include the maintainers.  Is the bi-annual DOI for each lesson still a feature?  This is probably something we should endeavor to get done by June.  Specifically, https://docs.carpentries.org/topic_folders/lesson_development/lesson_release.html

