### PR TITLE
Moved discussion of cell types to introduction of cells

### DIFF
--- a/_episodes/01-run-quit.md
+++ b/_episodes/01-run-quit.md
@@ -63,19 +63,18 @@ keypoints:
 > *   But this format allows Jupyter to mix source code, text, and images, all in one file.
 {: .callout}
 
-## The Notebook has Command and Edit modes.
-
-*   Open a new notebook from the dropdown menu (that says 'New') in the top right corner of the file browser page.
-*   Each notebook contains one or more cells that contain code, text, or images.
-
 > ## Code vs. Text
 >
-> We often use the term "code" to mean
-> "the source code of software written in a language such as Python". 
+> Jupyter mixes code and text in different types of blocks, called cells. We often use the term
+> "code" to mean "the source code of software written in a language such as Python".
 > A "code cell" in a Notebook is a cell that contains software;
 > a "text cell" is one that contains ordinary prose written for human beings.
 {: .callout}
 
+## The Notebook has Command and Edit modes.
+
+*   Open a new notebook from the dropdown menu (that says 'New') in the top right corner of the file browser page.
+*   Each notebook contains one or more cells that contain code, text, or images.
 *   If you press <kbd>Esc</kbd> and <kbd>Return</kbd> alternately,
     the outer border of your code cell will change from gray/blue to green.
     *   The difference in color is subtle.


### PR DESCRIPTION
This change moves the discussion of code vs. text cell types up to the first mention of cell types. I also added a very brief transitional sentence to introduce the word cell, since cells were previously referred to as blocks in the lesson.

This fixes #332, although I took a slightly different approach from the suggestion in that issue and moved the discussion up instead of down. I thought that it made the most sense to discuss cell types when the different types are first introduced.