### PR TITLE
Layout correction to references

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -1,4 +1,3 @@
-
 ---
 layout: reference
 permalink: /reference/


### PR DESCRIPTION
When my changes were merged the page no longer had the section summaries at the top. I've fixed this, so the layout should be correct now.