### PR TITLE
Import Pandas as pd in lesson 17, conditionals

### DIFF
--- a/_episodes/17-conditionals.md
+++ b/_episodes/17-conditionals.md
@@ -317,9 +317,9 @@ final velocity: 30.0
 >
 > ~~~
 > import glob
-> import pandas
+> import pandas as pd
 > for filename in glob.glob('data/*.csv'):
->     contents = pandas.read_csv(filename)
+>     contents = pd.read_csv(filename)
 >     ____:
 >         print(filename, len(contents))
 > ~~~
@@ -328,9 +328,9 @@ final velocity: 30.0
 > >
 > > ~~~
 > > import glob
-> > import pandas
+> > import pandas as pd
 > > for filename in glob.glob('data/*.csv'):
-> >     contents = pandas.read_csv(filename)
+> >     contents = pd.read_csv(filename)
 > >     if len(contents)<50:
 > >         print(filename, len(contents))
 > > ~~~


### PR DESCRIPTION
Import Pandas using the common alias 'pd' and use the alias in the examples and exercises.

Related to issue #382. Aliasing itself is introduced in the previous lesson and using it here would reiterate the topic. The shorthand itself is common and often assumed in examples and discussion, so I think it would be useful to introduce.