### PR TITLE
Add mention of the file browser opened by jupyter notebook

### DIFF
--- a/_episodes/01-run-quit.md
+++ b/_episodes/01-run-quit.md
@@ -40,6 +40,8 @@ keypoints:
     ~~~
 
 *   This will start a Jupyter Notebook server and open your default web browser. 
+*   The server first opens a file browser page where new notebooks can be created
+    or existing notebooks can be opened.
 *   The server runs locally on your machine only and does not use an internet connection.
 *   The server sends messages to your browser.
 *   The server does the work and the web browser renders the notebook.
@@ -52,6 +54,9 @@ keypoints:
         to make it more accessible to you and your collaborators.
     *   It allows you to display figures next to the code that produces them
         to tell a complete story of the analysis.
+
+An example of an open notebook is shown below. We will create a new notebook in
+later steps.
 
 ![Example Jupyter Notebook](../fig/0_jupyter_notebook_example.jpg)  
 *Screenshot of a [Jupyter Notebook on quantum mechanics](https://github.com/jrjohansson/qutip-lectures) by Robert Johansson*


### PR DESCRIPTION
Close #395.

As mentioned in #395 there is currently no mention of the file browser that is first shown in the browser window when starting the Jupyter Notebook server with `jupyter notebook`. A coworker was confused at why their screen (the file browser) was not the same as the screenshot shown.

I could see a better solution being a screenshot of the file browser before the current screenshot, but I'm not sure what files should be shown in the screenshot or if there are any preferred ways of making screenshots for lessons.

Feel free to ask me to change the language/tone of what I've changed. Thoughts?