### PR TITLE
Windows Anaconda Instructions

### DIFF
--- a/_episodes/01-run-quit.md
+++ b/_episodes/01-run-quit.md
@@ -74,11 +74,11 @@ $ jupyter lab
 {: .bash}
 
 ### Windows Users
-To start the JupyterLab server you will need to access the command line through the Command 
-Prompt. Use the shortcut keys <kbd>Windows Logo Key</kbd> + <kbd>R</kbd> to launch the Run window, 
-then type in `cmd` and press Enter.
+To start the JupyterLab server you will need to access the open Anaconda Prompt.
 
-After you have launched the Command Prompt, type the command:
+Press <kbd>Windows Logo Key</kbd> and search for `Anaconda Prompt`, click the result or press enter.
+
+After you have launched the Anaconda Prompt, type the command:
 
 ~~~
 $ jupyter lab


### PR DESCRIPTION
Changed instructions for launching Jupyter Lab on windows to specify Anaconda Prompt rather than CMD Prompt as per https://github.com/swcarpentry/python-novice-gapminder/issues/434

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
