### PR TITLE
Correct lifecycle metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ title: "Plotting and Programming in Python"
 
 # Life cycle stage of the lesson
 # possible values: "pre-alpha", "alpha", "beta", "stable"
-life_cycle: "beta"
+life_cycle: "stable"
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).


### PR DESCRIPTION
In case https://github.com/swcarpentry/python-novice-gapminder/commit/09550feeec221ad5027c7d5b9952fb7857c0777a included the `beta` setting _un_intentionally, please accept this PR. I'm guessing it was overlooked in #421's review, as this [lesson is listed as "core"](https://software-carpentry.org/lessons/) for a long time already ;-)