### PR TITLE
Consistent use of module and library

### DIFF
--- a/_episodes/06-libraries.md
+++ b/_episodes/06-libraries.md
@@ -7,8 +7,8 @@ questions:
 - "How can I find out what that software does?"
 objectives:
 - "Explain what software libraries are and why programmers create and use them."
-- "Write programs that import and use libraries from Python's standard library."
-- "Find and read documentation for standard libraries interactively (in the interpreter) and online."
+- "Write programs that import and use modules from Python's standard library."
+- "Find and read documentation for the standard library interactively (in the interpreter) and online."
 keypoints:
 - "Most of the power of a programming language is in its libraries."
 - "A program must import a library module in order to use it."
@@ -126,7 +126,7 @@ cos(pi) is -1.0
 {: .output}
 
 *   Commonly used for libraries that are frequently used or have long names.
-    *   E.g., `matplotlib` plotting library is often aliased as `mpl`.
+    *   E.g., the `matplotlib` plotting library is often aliased as `mpl`.
 *   But can make programs harder to understand,
     since readers must learn your program's aliases.
 

--- a/_episodes/14-looping-data-sets.md
+++ b/_episodes/14-looping-data-sets.md
@@ -54,8 +54,8 @@ dtype: float64
 *   The most common patterns are:
     *   `*` meaning "match zero or more characters"
     *   `?` meaning "match exactly one character"
-*   Python contains the [`glob`](https://docs.python.org/3/library/glob.html) library to provide pattern matching functionality
-*   The [`glob`](https://docs.python.org/3/library/glob.html) library contains a function also called `glob` to match file patterns
+*   Python's standard library contains the [`glob`](https://docs.python.org/3/library/glob.html) module to provide pattern matching functionality
+*   The [`glob`](https://docs.python.org/3/library/glob.html) module contains a function also called `glob` to match file patterns
 *   E.g., `glob.glob('*.txt')` matches all files in the current directory 
     whose names end with `.txt`.
 *   Result is a (possibly empty) list of character strings.


### PR DESCRIPTION
Hi,

I'm making a contribution for instructor training.

Issue #313 requested that the distinction between a "module" and a "library" be more consistent across episodes. After checking all instances of each term in the episode files, I believe there were only a couple instances that could use an update, which I've included. (I also added a stray missing "the").

Please let me know if you need any further changes to address the issue. 

Thanks!