### PR TITLE
Change "dock panel" for "main work area"

### DIFF
--- a/_episodes/01-run-quit.md
+++ b/_episodes/01-run-quit.md
@@ -111,7 +111,7 @@ menus are included by default.
 *   **View:** Actions that alter the appearance of JupyterLab.
 *   **Run:** Actions for running code in different activities such as notebooks and code consoles (discussed below).
 *   **Kernel:** Actions for managing kernels which, as mentioned above, are separate processes for running code.
-*   **Tabs:** A list of the open documents and activities in the dock panel.
+*   **Tabs:** A list of the open documents and activities in the main work area.
 *   **Settings:** Common JupyterLab settings can be configured using this menu. There is also an *Advanced Settings Editor* option in the dropdown menu that provides more fine-grained control of JupyterLab settings and configuration options.
 *   **Help:** A list of JupyterLab and kernel help links.
 


### PR DESCRIPTION
In the lesson 01-run-quit.md the expression dock panel
was being used once instead of main work area.

This PR is for issue #480.
