### PR TITLE
Fixed broken links to other episodes

### DIFF
--- a/_episodes/03-types-conversion.md
+++ b/_episodes/03-types-conversion.md
@@ -427,7 +427,7 @@ first is 2 and second is 5
 >
 > Python provides complex numbers,
 > which are written as `1.0+2.0j`.
-> If `val` is an imaginary number,
+> If `val` is a complex number,
 > its real and imaginary parts can be accessed using *dot notation*
 > as `val.real` and `val.imag`.
 >

--- a/_episodes/06-libraries.md
+++ b/_episodes/06-libraries.md
@@ -199,7 +199,7 @@ cos(pi) is -1.0
 > > {: .language-python}
 > >
 > > Note that this function returns a list of values. We will learn about
-> > lists in [episode 11]({% link _episodes/11-lists.md %}).
+> > lists in [episode 11]({{ page.root }}/11-lists/).
 > >
 > > There's also other functions you could use, but with more convoluted
 > > code as a result.

--- a/_episodes/11-lists.md
+++ b/_episodes/11-lists.md
@@ -138,7 +138,7 @@ primes after removing last item: [2, 3, 5, 7]
 *   Use `[]` on its own to represent a list that doesn't contain any values.
     *   "The zero of lists."
 *   Helpful as a starting point for collecting values
-        (which we will see in the [next episode]({% link _episodes/12-for-loops.md %}).
+        (which we will see in the [next episode]({{ page.root }}/12-for-loops/).
 
 ## Lists may contain values of different types.
 


### PR DESCRIPTION
I found two broken links in the documentation. I tried to fix them by using `page.root` instead of the relative link. I checked it locally (after running make serve) and it seemed to work. Hopefully it also works for the Github pages.