### PR TITLE
monospace example line style arguments

### DIFF
--- a/_episodes/09-plotting.md
+++ b/_episodes/09-plotting.md
@@ -94,7 +94,7 @@ plt.ylabel('GDP per capita')
 
 ## Data can also be plotted by calling the `matplotlib` `plot` function directly.
 *   The command is `plt.plot(x, y)`
-*   The color / format of markers can also be specified as an optical argument: e.g. 'b-' is a blue line, 'g--' is a green dashed line.
+*   The color / format of markers can also be specified as an optical argument: e.g. `b-` is a blue line, `g--` is a green dashed line.
 
 ## Get Australia data from dataframe
 

--- a/_episodes/09-plotting.md
+++ b/_episodes/09-plotting.md
@@ -94,7 +94,7 @@ plt.ylabel('GDP per capita')
 
 ## Data can also be plotted by calling the `matplotlib` `plot` function directly.
 *   The command is `plt.plot(x, y)`
-*   The color / format of markers can also be specified as an optical argument: e.g. `b-` is a blue line, `g--` is a green dashed line.
+*   The color and format of markers can also be specified as an additional optional argument e.g., `b-` is a blue line, `g--` is a green dashed line.
 
 ## Get Australia data from dataframe
 


### PR DESCRIPTION
viewed in the browser at http://swcarpentry.github.io/python-novice-gapminder/09-plotting/index.html, `g--` seems to be displaying as "g–" (see attached screenshot). This PR eliminates the potential confusion by wrapping the examples in the episode body in backticks, so that they are rendered on the page in monospaced font.

<img width="1157" alt="Screenshot 2020-07-20 at 13 45 38" src="https://user-images.githubusercontent.com/9694524/87934777-07039c80-ca90-11ea-892c-a24485603e42.png">
