### PR TITLE
Links to images changed to absolute

### DIFF
--- a/_episodes/01-run-quit.md
+++ b/_episodes/01-run-quit.md
@@ -88,7 +88,7 @@ Below is a screenshot of a similar JupyterLab landing page to the one that shoul
 default web browser after starting the JupyterLab server on wither Mac OS X or Windows.
 
 <p align='center'>
-  <img alt="JupyterLab landing page" src="../fig/0_jupyterlab_landing_page.png" width="750"/>
+  <img alt="JupyterLab landing page" src="{{ site.baseurl }}/fig/0_jupyterlab_landing_page.png" width="750"/>
 </p>
 
 ## The JupyterLab Interface
@@ -118,7 +118,7 @@ menus are included by default.
 A screenshot of the default Menu Bar is provided below.
 
 <p align='center'>
-    <img alt="JupyterLab Menu Bar" src="../fig/0_jupyterlab_menu_bar.png" width="750"/>
+    <img alt="JupyterLab Menu Bar" src="{{ site.baseurl }}/fig/0_jupyterlab_menu_bar.png" width="750"/>
 </p>
 
 ### Left Sidebar
@@ -129,7 +129,7 @@ and terminals, the command palette, and a list of open tabs in the main work are
 the default Left Side Bar is provided below.
 
 <p align='center'>
-    <img alt="JupyterLab Left Side Bar" src="../fig/0_jupyterlab_left_side_bar.png" width="250"/>
+    <img alt="JupyterLab Left Side Bar" src="{{ site.baseurl }}/fig/0_jupyterlab_left_side_bar.png" width="250"/>
 </p>
 
 The left sidebar can be collapsed or expanded by selecting “Show Left Sidebar” in the View menu or 
@@ -142,7 +142,7 @@ and other activities (terminals, code consoles, etc.) into panels of tabs that c
 subdivided. A screenshot of the default Menu Bar is provided below.
 
 <p align='center'>
-    <img alt="JupyterLab Main Work Area" src="../fig/0_jupyterlab_main_work_area.png" width="750"/>
+    <img alt="JupyterLab Main Work Area" src="{{ site.baseurl }}/fig/0_jupyterlab_main_work_area.png" width="750"/>
 </p>
 
 Drag a tab to the center of a tab panel to move the tab to the panel. Subdivide a tab panel by 
@@ -171,7 +171,7 @@ Below is a screenshot of a Jupyter notebook running inside JupyterLab. If you ar
 more details, then see the [official notebook documentation][jupyterlab-notebook-docs].
 
 <p align='center'>
-    <img alt="Example Jupyter Notebook" src="../fig/0_jupyterlab_notebook_screenshot.png" width="750"/>
+    <img alt="Example Jupyter Notebook" src="{{ site.baseurl }}/fig/0_jupyterlab_notebook_screenshot.png" width="750"/>
 </p>
 
 > ## How It's Stored
@@ -187,7 +187,7 @@ more details, then see the [official notebook documentation][jupyterlab-notebook
 > example from the [official documentation][jupyterlab].
 > 
 > <p align='center'>
->    <img alt="Multi-panel JupyterLab" src="../fig/0_multipanel_jupyterlab_screenshot.png" width="750"/>
+>    <img alt="Multi-panel JupyterLab" src="{{ site.baseurl }}/fig/0_multipanel_jupyterlab_screenshot.png" width="750"/>
 > </p>
 >
 > First, create a text file, Python console, and terminal window and arrange them into three 

--- a/_episodes/02-variables.md
+++ b/_episodes/02-variables.md
@@ -131,7 +131,7 @@ Age in three years: 45
 *   Use the position's index in square brackets to get the character at that
     position.
     
-![an illustration of indexing](../fig/2_indexing.svg)
+![an illustration of indexing]({{ site.baseurl }}/fig/2_indexing.svg)
 
 ~~~
 atom_name = 'helium'

--- a/_episodes/09-plotting.md
+++ b/_episodes/09-plotting.md
@@ -38,7 +38,7 @@ plt.ylabel('Position (km)')
 ~~~
 {: .language-python}
 
-![Simple Position-Time Plot](../fig/9_simple_position_time_plot.svg)
+![Simple Position-Time Plot]({{ site.baseurl }}/fig/9_simple_position_time_plot.svg)
 ## Plot data directly from a [`Pandas dataframe`](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html).
 
 *   We can also plot [Pandas dataframes](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html).
@@ -66,7 +66,7 @@ data.loc['Australia'].plot()
 ~~~
 {: .language-python}
 
-![GDP plot for Australia](../fig/9_gdp_australia.svg)
+![GDP plot for Australia]({{ site.baseurl }}/fig/9_gdp_australia.svg)
 ## Select and transform data, then plot it.
 
 *   By default, [`DataFrame.plot`](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.plot.html#pandas.DataFrame.plot) plots with the rows as the X axis.
@@ -78,7 +78,7 @@ plt.ylabel('GDP per capita')
 ~~~
 {: .language-python}
 
-![GDP plot for Australia and New Zealand](../fig/9_gdp_australia_nz.svg)
+![GDP plot for Australia and New Zealand]({{ site.baseurl }}/fig/9_gdp_australia_nz.svg)
 ## Many styles of plot are available.
 
 *   For example, do a bar plot using a fancier style.
@@ -90,7 +90,7 @@ plt.ylabel('GDP per capita')
 ~~~
 {: .language-python}
 
-![GDP barplot for Australia](../fig/9_gdp_bar.svg)
+![GDP barplot for Australia]({{ site.baseurl }}/fig/9_gdp_bar.svg)
 
 ## Data can also be plotted by calling the `matplotlib` `plot` function directly.
 *   The command is `plt.plot(x, y)`
@@ -106,7 +106,7 @@ plt.plot(years, gdp_australia, 'g--')
 ~~~
 {: .language-python}
 
-![GDP formatted plot for Australia](../fig/9_gdp_australia_formatted.svg)
+![GDP formatted plot for Australia]({{ site.baseurl }}/fig/9_gdp_australia_formatted.svg)
 
 ## Can plot many sets of data together.
 
@@ -153,7 +153,7 @@ plt.ylabel('GDP per capita ($)')
 {: .callout}
 
 
-![GDP formatted plot for Australia and New Zealand](../fig/9_gdp_australia_nz_formatted.svg)
+![GDP formatted plot for Australia and New Zealand]({{ site.baseurl }}/fig/9_gdp_australia_nz_formatted.svg)
 *   Plot a scatter plot correlating the GDP of Australia and New Zealand
 *   Use either `plt.scatter` or `DataFrame.plot.scatter`
 
@@ -162,13 +162,13 @@ plt.scatter(gdp_australia, gdp_nz)
 ~~~
 {: .language-python}
 
-![GDP correlation using plt.scatter](../fig/9_gdp_correlation_plt.svg)
+![GDP correlation using plt.scatter]({{ site.baseurl }}/fig/9_gdp_correlation_plt.svg)
 ~~~
 data.T.plot.scatter(x = 'Australia', y = 'New Zealand')
 ~~~
 {: .language-python}
 
-![GDP correlation using data.T.plot.scatter](../fig/9_gdp_correlation_data.svg)
+![GDP correlation using data.T.plot.scatter]({{ site.baseurl }}/fig/9_gdp_correlation_data.svg)
 
 > ## Minima and Maxima
 >
@@ -195,7 +195,7 @@ data.T.plot.scatter(x = 'Australia', y = 'New Zealand')
 > > plt.xticks(rotation=90)
 > > ~~~
 > > {: .language-python}
-> > ![Minima Maxima Solution](../fig/9_minima_maxima_solution.png)
+> > ![Minima Maxima Solution]({{ site.baseurl }}/fig/9_minima_maxima_solution.png)
 > {: .solution}
 {: .challenge}
 
@@ -214,7 +214,7 @@ data.T.plot.scatter(x = 'Australia', y = 'New Zealand')
 >
 > > ## Solution
 > >
-> > ![Correlations Solution 1](../fig/9_correlations_solution1.svg)
+> > ![Correlations Solution 1]({{ site.baseurl }}/fig/9_correlations_solution1.svg)
 > >
 > > No particular correlations can be seen between the minimum and maximum gdp values
 > > year on year. It seems the fortunes of asian countries do not rise and fall together.
@@ -231,7 +231,7 @@ data.T.plot.scatter(x = 'Australia', y = 'New Zealand')
 > ~~~
 > {: .language-python}
 > > ## Solution
-> > ![Correlations Solution 2](../fig/9_correlations_solution2.png)
+> > ![Correlations Solution 2]({{ site.baseurl }}/fig/9_correlations_solution2.png)
 > >
 > > Seems the variability in this value is due to a sharp drop after 1972.
 > > Some geopolitics at play perhaps? Given the dominance of oil producing countries,
@@ -258,7 +258,7 @@ data.T.plot.scatter(x = 'Australia', y = 'New Zealand')
 > explain what each argument to `plot` does.
 >
 > > ## Solution
-> > ![More Correlations Solution](../fig/9_more_correlations_solution.svg)
+> > ![More Correlations Solution]({{ site.baseurl }}/fig/9_more_correlations_solution.svg)
 > >
 > > A good place to look is the documentation for the plot function -
 > > help(data_all.plot).

--- a/index.md
+++ b/index.md
@@ -30,7 +30,7 @@ as well. Please note that this lesson uses Python 3 rather than Python 2.
 >
 > 3. Learners must get the gapminder data before class starts:
 >    please download and unzip the file 
->    [python-novice-gapminder-data.zip]({{page.root}}/files/python-novice-gapminder-data.zip).
+>    [python-novice-gapminder-data.zip]({{ site.baseurl }}/files/python-novice-gapminder-data.zip).
 >
 >    Please see [the setup instructions][lesson-setup]
 >    for details.

--- a/setup.md
+++ b/setup.md
@@ -72,7 +72,7 @@ If you run into any difficulties, please request help before the workshop begins
 
 The data we will be using is taken from the [gapminder][gapminder] dataset.
 To obtain it, download and unzip the file 
-[python-novice-gapminder-data.zip]({{page.root}}/files/python-novice-gapminder-data.zip).
+[python-novice-gapminder-data.zip]({{ site.baseurl }}/files/python-novice-gapminder-data.zip).
 In order to follow the presented material, you should launch the JupyterLab 
 server in the root directory (see [Starting JupyterLab]({{ page.root }}/01-run-quit/#starting-jupyterlab)).
 


### PR DESCRIPTION
This is needed for the translations as otherwise the image links need to be
also "translated" to a different location.

You can see that this also works on the [first episode of the Translations fork](https://carpentries-i18n.github.io/python-novice-gapminder/01-run-quit/index.html)
