### PR TITLE
Add a table for arithmetic operators

### DIFF
--- a/_episodes/02-variables.md
+++ b/_episodes/02-variables.md
@@ -109,6 +109,16 @@ NameError: name 'last_name' is not defined
 
 *   We can use variables in calculations just as if they were values.
     *   Remember, we assigned the value `42` to `age` a few lines ago.
+*   Python has a set of built-in arithmetic operators for calculations. 
+
+| Operation     | Operator | 
+|-------------- | -------- |
+| Addition      |    +     |
+| Subtraction   |    -     | 
+| Division      |    /     |
+| Multiplication|    *     |
+| Exponentiation|    **    |
+| Modulus       |    %     |
 
 ~~~
 age = age + 3


### PR DESCRIPTION
I was recently teaching this lesson and a student was confused about the arithmetic operators (younger student who likely had only, for example, used a calculator with the standard division sign). For that reason, I added a small table with the arithmetic operators before the first operation is performed, just for the students to have for reference. I figured that a table would add minimally to the lesson time while also providing the background for students who might be unfamiliar.