### PR TITLE
Add space around <div> tags

### DIFF
--- a/_episodes/01-run-quit.md
+++ b/_episodes/01-run-quit.md
@@ -284,36 +284,45 @@ more details, then see the [official notebook documentation][jupyterlab-notebook
 
 <div class="row">
   <div class="col-md-6" markdown="1">
+    
 ~~~
 *   Use asterisks
 *   to create
 *   bullet lists.
 ~~~
+
   </div>
   <div class="col-md-6" markdown="1">
+  
 *   Use asterisks
 *   to create
 *   bullet lists.
+
   </div>
 </div>
 
 <div class="row">
   <div class="col-md-6" markdown="1">
+    
 ~~~
 1.  Use numbers
 1.  to create
 1.  numbered lists.
 ~~~
+
   </div>
   <div class="col-md-6" markdown="1">
+
 1.  Use numbers
 1.  to create
 1.  numbered lists.
+
   </div>
 </div>
 
 <div class="row">
   <div class="col-md-6" markdown="1">
+    
 ~~~
 *  You can use indents
 	*  To create sublists 
@@ -322,41 +331,53 @@ more details, then see the [official notebook documentation][jupyterlab-notebook
 	1. Of different
 	1. types
 ~~~
+
   </div>
   <div class="col-md-6" markdown="1">
+  
 *  You can use indents
 	*  To create sublists
 	*  of the same type
 *  Or sublists
 	1. Of different
 	1. types
+  
   </div>
 </div>
 
 <div class="row">
   <div class="col-md-6" markdown="1">
+    
 ~~~
 # A Level-1 Heading
 ~~~
+
   </div>
   <div class="col-md-6" markdown="1">
+  
 # A Level-1 Heading
+
   </div>
 </div>
 
 <div class="row">
   <div class="col-md-6" markdown="1">
+    
 ~~~
 ## A Level-2 Heading (etc.)
 ~~~
+
   </div>
   <div class="col-md-6" markdown="1">
+  
 ## A Level-2 Heading (etc.)
+
   </div>
 </div>
 
 <div class="row">
   <div class="col-md-6" markdown="1">
+    
 ~~~
 Line breaks
 don't matter.
@@ -364,30 +385,37 @@ don't matter.
 But blank lines
 create new paragraphs.
 ~~~
+
   </div>
   <div class="col-md-6" markdown="1">
+  
 Line breaks
 don't matter.
 
 But blank lines
 create new paragraphs.
+
   </div>
 </div>
 
 <div class="row">
   <div class="col-md-6" markdown="1">
+    
 ~~~
 [Create links](http://software-carpentry.org) with `[...](...)`.
 Or use [named links][data_carpentry].
 
 [data_carpentry]: http://datacarpentry.org
 ~~~
+
   </div>
   <div class="col-md-6" markdown="1">
+  
 [Create links](http://software-carpentry.org) with `[...](...)`.
 Or use [named links][data_carpentry].
 
 [data_carpentry]: http://datacarpentry.org
+
   </div>
 </div>
 


### PR DESCRIPTION
## Problem

Github's markdown parser gets confused because [some of the code fences inside div elements are not parsed as markdown](https://github.com/swcarpentry/python-novice-gapminder/blob/a2fbcf1c9e8aa0b770f93cd5012d9d4cfbd821ca/_episodes/01-run-quit.md#markdown-does-most-of-what-html-does)

<img src="https://user-images.githubusercontent.com/3639446/93919881-34a0d800-fcc3-11ea-9edc-f3aa377d41a6.png" alt="screen capture showing incorrectly parsed markdown where div tags are included in code blocks" width="50%" />

## Solution

This PR adds blank lines around div tags to avoid mistakes in parsing for markdown engines that are based on the [strict markdown spec for including HTML elements](https://daringfireball.net/projects/markdown/syntax#html) states:

> The only restrictions are that block-level HTML elements — e.g. `<div>, <table>, <pre>, <p>`, etc. — must be separated from surrounding content by blank lines
