### PR TITLE
make lesson suitable for teaching with locally-built (serverless) pages

### DIFF
--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/design.md
+++ b/_extras/design.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: "Lesson Design"
-permalink: /design/
 ---
 
 > ## Help Wanted
@@ -28,11 +26,11 @@ This lesson was developed using a slimmed-down variant of the "Understanding by 
 The main sections are:
 
 1.  Assumptions about audience, time, etc.
-    (The current draft also includes some conclusions and decisions in this 
+    (The current draft also includes some conclusions and decisions in this
     section - that should be refactored.)
 
 2.  Desired results:
-    overall goals, summative assessments at half-day granularity, what learners 
+    overall goals, summative assessments at half-day granularity, what learners
     will be able to do, what learners will know.
 
 3.  Learning plan:
@@ -65,7 +63,7 @@ The main sections are:
     *   Creating 2D plots suitable for inclusion in papers
     *   Appeals to almost everyone
     *   Makes lesson usable by both Carpentries
-        *   And means that even people who have seen a bit of Python before 
+        *   And means that even people who have seen a bit of Python before
             will probably learn something
 *   Data
     *   Use the gapminder data throughout
@@ -118,7 +116,7 @@ I know...
     *   Modularity for readability as well as re-use
     *   No duplication
     *   Document purpose and use
-*   ...that there is no magic: the programs they use are no different 
+*   ...that there is no magic: the programs they use are no different
     in principle from those they build
 *   ...how to assign values to variables
 *   ...what integers, floats, strings, NumPy arrays, and Pandas dataframes are

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: "Discussion"
-permalink: /discuss/
 ---
 FIXME: general discussion and further reading for learners.

--- a/_extras/exercises.md
+++ b/_extras/exercises.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: "Further Exercises"
-permalink: /exercises/
 ---
 FIXME: exercises that don't fit into the regular schedule.

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: "Instructors' Guide"
-permalink: /guide/
 ---
 
 ## General Notes

--- a/reference.md
+++ b/reference.md
@@ -1,7 +1,5 @@
 ---
 layout: reference
-permalink: /reference/
-root: ..
 ---
 
 ## Reference
@@ -27,7 +25,7 @@ root: ..
   - Take a slice using `[start:stop]`. This makes a copy of part of the original string.
     - `start` is the index of the first element.
     - `stop` is the index of the element after the last desired element.
-- Use `len(...)` to find the length of a variable or string. 
+- Use `len(...)` to find the length of a variable or string.
 
 ## [Data Types and Type Conversion]({{ page.root }}/03-types-conversion/)
 - Each value has a type. This controls what can be done with it.

--- a/setup.md
+++ b/setup.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: "Setup"
-permalink: /setup/
-root: ..
 ---
 
 ## Installing Python Using Anaconda
@@ -13,8 +10,8 @@ individually can be a bit difficult, however, so we recommend the all-in-one
 installer [Anaconda][anaconda].
 
 Regardless of how you choose to install it, please make sure you install Python
-version 3.x (e.g., 3.4 is fine). Also, please set up your python environment at 
-least a day in advance of the workshop.  If you encounter problems with the 
+version 3.x (e.g., 3.4 is fine). Also, please set up your python environment at
+least a day in advance of the workshop.  If you encounter problems with the
 installation procedure, ask your workshop organizers via e-mail for assistance so
 you are ready to go as soon as the workshop begins.
 
@@ -37,7 +34,7 @@ you are ready to go as soon as the workshop begins.
 
 ### Linux
 
-Note that the following installation steps require you to work from the shell. 
+Note that the following installation steps require you to work from the shell.
 If you run into any difficulties, please request help before the workshop begins.
 
 1.  Open [https://www.anaconda.com/distribution/][anaconda-linux] with your web browser.
@@ -62,18 +59,18 @@ If you run into any difficulties, please request help before the workshop begins
     d.  Press enter.
 
     e.  Follow the text-only prompts.  When the license agreement appears (a colon
-        will be present at the bottom of the screen) press the space bar until you see the 
-        bottom of the text. Type `yes` and press enter to approve the license. Press 
-        enter again to approve the default location for the files. Type `yes` and 
-        press enter to prepend Anaconda to your `PATH` (this makes the Anaconda 
+        will be present at the bottom of the screen) press the space bar until you see the
+        bottom of the text. Type `yes` and press enter to approve the license. Press
+        enter again to approve the default location for the files. Type `yes` and
+        press enter to prepend Anaconda to your `PATH` (this makes the Anaconda
         distribution your user's default Python).
 
 ## Getting the Data
 
 The data we will be using is taken from the [gapminder][gapminder] dataset.
-To obtain it, download and unzip the file 
+To obtain it, download and unzip the file
 [python-novice-gapminder-data.zip]({{page.root}}/files/python-novice-gapminder-data.zip).
-In order to follow the presented material, you should launch the JupyterLab 
+In order to follow the presented material, you should launch the JupyterLab
 server in the root directory (see [Starting JupyterLab]({{ page.root }}/01-run-quit/#starting-jupyterlab)).
 
 


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use the path `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Software Carpentry Lessons page](https://software-carpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I did a sweep through the lesson and adjusted internal links as part of this PR. If and when this is merged, I'll also make sure the link on https://software-carpentry.org/lessons/ to the Instructor Notes page isn't broken, and make another sweep through the lesson pages too. 

Finally, I also removed the `layout` field from several pages, as the default layout is already set for Episodes and Extras pages in `_config.yml`.