### PR TITLE
adding a note about plt.show()

### DIFF
--- a/_episodes/09-plotting.md
+++ b/_episodes/09-plotting.md
@@ -43,7 +43,7 @@ plt.ylabel('Position (km)')
 
 
 
-> ## Display all open figures
+> ## Display All Open Figures
 > 
 > Within the Jupyter Notebook environment, a created figure will by output when
 > the cell is run. However, in other Python environments, an additional command
@@ -165,17 +165,19 @@ plt.ylabel('GDP per capita ($)')
 > plt.plot(years, gdp_australia, label='Australia')
 > plt.plot(years, gdp_nz, label='New Zealand')
 > ~~~
+> {: .language-python}
 >
 > * Instruct `matplotlib` to create the legend.
 >
 > ~~~
 > plt.legend()
 > ~~~
+> {: .language-python}
 >
 > By default matplotlib will attempt to place the legend in a suitable position. If you
 > would rather specify a position this can be done with the `loc=` argument, e.g to place
 > the legend in the upper left corner of the plot, specify `loc='upper left'`
-> {: .language-python}
+>
 {: .callout}
 
 

--- a/_episodes/09-plotting.md
+++ b/_episodes/09-plotting.md
@@ -39,6 +39,32 @@ plt.ylabel('Position (km)')
 {: .language-python}
 
 ![Simple Position-Time Plot](../fig/9_simple_position_time_plot.svg)
+
+
+
+
+> ## Display all open figures
+> 
+> Within the Jupyter Notebook environment, a created figure will by output when
+> the cell is run. However, in other Python environments, an additional command
+> is needed to display the figure.
+>
+> * Instruct `matplotlib` to create show the figure.
+>
+> ~~~
+> plt.show()
+> ~~~
+> {: .language-python}
+>
+> Note: this command can also be used within a Notebook to display all the figures
+> if several are created in the same cell.
+{: .callout}
+
+
+
+
+
+
 ## Plot data directly from a [`Pandas dataframe`](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html).
 
 *   We can also plot [Pandas dataframes](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html).

--- a/_episodes/09-plotting.md
+++ b/_episodes/09-plotting.md
@@ -45,12 +45,11 @@ plt.ylabel('Position (km)')
 
 > ## Display All Open Figures
 > 
-> Within the Jupyter Notebook environment, a created figure will by output when
+> Within the Jupyter Notebook environment, the last created figure will be output when
 > the cell is run. However, in other Python environments, an additional command
 > is needed to display the figure.
 >
-> * Instruct `matplotlib` to create show the figure.
->
+> Instruct `matplotlib` to show the figure:
 > ~~~
 > plt.show()
 > ~~~
@@ -58,6 +57,7 @@ plt.ylabel('Position (km)')
 >
 > Note: this command can also be used within a Notebook to display all the figures
 > if several are created in the same cell.
+>
 {: .callout}
 
 

--- a/_episodes/09-plotting.md
+++ b/_episodes/09-plotting.md
@@ -45,18 +45,18 @@ plt.ylabel('Position (km)')
 
 > ## Display All Open Figures
 > 
-> Within the Jupyter Notebook environment, the last created figure will be output when
-> the cell is run. However, in other Python environments, an additional command
-> is needed to display the figure.
+> In our Jupyter Notebook example with `%matplotlib inline`, running the cell generates the figure directly below the code. 
+> The figure is also included in the Notebook document for future viewing.
+> However, other Python environments require an additional command in order to display the figure.
 >
-> Instruct `matplotlib` to show the figure:
+> Instruct `matplotlib` to show a figure:
 > ~~~
 > plt.show()
 > ~~~
 > {: .language-python}
 >
-> Note: this command can also be used within a Notebook to display all the figures
-> if several are created in the same cell.
+> This command can also be used within a Notebook - for instance, to display multiple figures
+> if several are created by a single cell.
 >
 {: .callout}
 

--- a/_episodes/09-plotting.md
+++ b/_episodes/09-plotting.md
@@ -40,9 +40,6 @@ plt.ylabel('Position (km)')
 
 ![Simple Position-Time Plot](../fig/9_simple_position_time_plot.svg)
 
-
-
-
 > ## Display All Open Figures
 > 
 > In our Jupyter Notebook example with `%matplotlib inline`, running the cell generates the figure directly below the code. 
@@ -59,11 +56,6 @@ plt.ylabel('Position (km)')
 > if several are created by a single cell.
 >
 {: .callout}
-
-
-
-
-
 
 ## Plot data directly from a [`Pandas dataframe`](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html).
 


### PR DESCRIPTION
Issue #482 requested a short note explaining plt.show() for users with other Python interpreters.  This PR:

- adds this note right below the first figure generated
- fixes some erroneous Python code block highlighting in the section `Adding a Legend`