### PR TITLE
Introducing methods in episode 4, and using them in episodes 7 and 8

### DIFF
--- a/_episodes/04-built-in.md
+++ b/_episodes/04-built-in.md
@@ -137,6 +137,44 @@ round(3.712, 1)
 ~~~
 {: .output}
 
+## Functions attached to objects are called methods
+
+* Functions take another form that will be common in the pandas episodes.
+* Methods have parentheses like functions, but come after the variable.
+* Some methods aren't used often, and are marked with double underlines.
+
+~~~
+my_string = 'Hello world!'  # creation of a string object 
+
+print(len(my_string))       # function with the string as an argument
+
+print(my_string.__len__())  # method acting upon the string object
+~~~
+{: .language-python}
+
+~~~
+12
+12
+~~~
+{: .output}
+
+* You might even see them chained together.  They operate left to right.
+
+~~~
+print(my_string.isupper())          # Not all the letters are uppercase
+print(my_string.upper())            # This capitalizes all the letters
+
+print(my_string.upper().isupper())  # Now all the letters are uppercase
+~~~
+{: .language-python}
+
+~~~
+False
+HELLO WORLD
+True
+~~~
+{: .output}
+
 ## Use the built-in function `help` to get help for a function.
 
 *   Every built-in function has online documentation.

--- a/_episodes/07-reading-tabular.md
+++ b/_episodes/07-reading-tabular.md
@@ -100,7 +100,7 @@ New Zealand     18363.32494     21050.41377     23189.80135     25185.00911
 ~~~
 {: .output}
 
-## Use `DataFrame.info` to find out more about a dataframe.
+## Use the `DataFrame.info()` method to find out more about a dataframe.
 
 ~~~
 data.info()
@@ -135,7 +135,7 @@ memory usage: 208.0+ bytes
 
 ## The `DataFrame.columns` variable stores information about the dataframe's columns.
 
-*   Note that this is data, *not* a method.
+*   Note that this is data, *not* a method.  (It doesn't have parentheses.)
     *   Like `math.pi`.
     *   So do not use `()` to try to call it.
 *   Called a *member variable*, or just *member*.
@@ -179,9 +179,9 @@ gdpPercap_2007  34435.36744  25185.00911
 ~~~
 {: .output}
 
-## Use `DataFrame.describe` to get summary statistics about data.
+## Use `DataFrame.describe()` to get summary statistics about data.
 
-DataFrame.describe() gets the summary statistics of only the columns that have numerical data. 
+`DataFrame.describe()` gets the summary statistics of only the columns that have numerical data. 
 All other columns are ignored, unless you use the argument `include='all'`.
 ~~~
 print(data.describe())

--- a/_episodes/08-data-frames.md
+++ b/_episodes/08-data-frames.md
@@ -298,7 +298,7 @@ dtype: float64
 {: .output}
 
 Finally, for each group in the `wealth_score` table, we sum their (financial) contribution
-across the years surveyed:
+across the years surveyed using chained methods:
 
 ~~~
 data.groupby(wealth_score).sum()
@@ -511,45 +511,38 @@ data.groupby(wealth_score).sum()
 {: .challenge}
 
 
-> ## Using the dir function to see available methods
+> ## Exploring available methods using the `dir()` function
 >
-> Python includes a `dir` function that can be used to display all of the available methods (functions) that are built into a data object.  As an example, the  functions available for a [list data type](https://docs.python.org/3/tutorial/datastructures.html#more-on-lists) are:
+> Python includes a `dir()` function that can be used to display all of the available methods (functions) that are built into a data object.  In Episode 4, we used some methods with a string. But we can see many more are available by using `dir()`:
+>
 > ~~~
-> potatoes = ["Russet", "Norkota", "Yukon Gold", "Pontiac"]
-> dir(potatoes)
+> my_string = 'Hello world!'   # creation of a string object 
+> dir(myString)
 > ~~~
 > {: .language-python}
 >
 > This command returns:
+>
 > ~~~
 > ['__add__',
 > ...
 > '__subclasshook__',
->  'append',
->  'clear',
->  'copy',
->  'count',
-> 'extend',
-> 'index',
-> 'insert',
-> 'pop',
-> 'remove',
-> 'reverse',
-> 'sort']
+> 'capitalize',
+> 'casefold',
+> 'center',
+> ...
+> 'upper',
+> 'zfill']
 > ~~~
 > {: .language-python}
 >
-> The double underscore functions can be ignored for now; functions that are not surrounded by double underscores are the *public interface* of the [list type](https://docs.python.org/3/tutorial/datastructures.html#more-on-lists). So, if you want to sort the list of potatoes, according to `dir` you should try,
-> ~~~
-> potatoes.sort()
-> ~~~
-> {: .language-python}
+> You can use `help()` or shift-tab to get more information about what these methods do.
 >
-> Assume Pandas has been imported and the Gapminder GDP data for Europe has been loaded as `data`.  Then, use `dir` to find the function that prints out the median per-capita GDP across all European countries for each year that information is available.  
+> Assume Pandas has been imported and the Gapminder GDP data for Europe has been loaded as `data`.  Then, use `dir()` to find the function that prints out the median per-capita GDP across all European countries for each year that information is available.  
 {: .challenge}
 >
 > > ## Solution
-> > Among many choices, dir lists the `median()` function as a possibility.  Thus,
+> > Among many choices, `dir()` lists the `median()` function as a possibility.  Thus,
 > > ~~~
 > > data.median()
 > > ~~~


### PR DESCRIPTION
This PR is to address issue #473 which requests an introduction to methods be added before methods are used in the pandas episodes.  This PR:

* adds an example of methods using strings in Episode 4
* updates some text in Episode 7 - the first time I could find where a method is used
* changes the dir() exercise in Episode 8 (PR #341) to use strings instead of a list. This provides continuity and avoids using lists, which haven't been introduced yet.

I would like to add a couple changes to this PR, but I wanted to check first, because they aren't directly related. These are all in Episode 7

* ~~A reference to `math.pi` is made when introducing `DataFrame.columns`. I would remove that because I don't see any other references to `math`, which makes it confusing to me.~~  I just noticed the libraries lesson that covers that.  Should have seen that before.
* Transposing is introduced as `data.T` and it is described as being like `DataFrame.columns`.  I would substitute `data.transpose()` because `T` isn't like `columns`.  `columns` is an attribute and according to the [pandas docs](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.transpose.html?highlight=transpose#pandas.DataFrame.transpose), "The property T is an accessor to the method transpose()."  I'm not sure I could explain what that means, so I'd like to use the function instead. `T` could then be described as a "shortcut".
* Methods are described as "members" and attributes like `columns` are described as "member variables". I've never seen that terminology before. Does it come from another language. like C++?  I would like to use the terms "attribute" and "methods" exclusively since those are used in the [DataFrame pandas docs](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).

Please, let me know what you think about those 3 additional changes.