### PR TITLE
Add .jekyll-cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ _site
 .Rproj.user
 .Rhistory
 .RData
+.jekyll-cache
 


### PR DESCRIPTION
When serving the website of the lesson locally, Jekyll creates
a `.jekyll-cache` folder which shouldn't be pushed to the repository.
Would be better to tell `git` to ignore it so it never gets pushed by
accident.
For reference, the `.jekyll-cache` directory is already being ignored on
the [carpentries/lesson-example](https://github.com/carpentries/lesson-example) (see [bd56b2](https://github.com/carpentries/lesson-example/commit/bd56b2b083cb5929d603836e4024738cd5058ced)).
