### PR TITLE
04-built-in.md: fix nested Markdown list

### DIFF
--- a/_episodes/04-built-in.md
+++ b/_episodes/04-built-in.md
@@ -288,7 +288,7 @@ NameError: name 'aege' is not defined
 > ~~~
 > {: .language-python}
 > > ## Solution
-> > 1.
+> > 1. Order of operations:
 > >    1. `1.1 * radiance = 1.1`
 > >    2. `1.1 - 0.5 = 0.6`
 > >    3. `min(radiance, 0.6) = 0.6`


### PR DESCRIPTION
Without any text in the first bullet point, the list is rendered incorrectly:

![image](https://user-images.githubusercontent.com/13123663/109525999-b6b5d980-7a77-11eb-8f57-e17603eb2b2a.png)


This PR adds minimal amount of text to fix this:

![image](https://user-images.githubusercontent.com/13123663/109526043-c2090500-7a77-11eb-8ffa-52c84da13722.png)
