### PR TITLE
setup.md: Update Python installation instructions

### DIFF
--- a/_includes/python_install.html
+++ b/_includes/python_install.html
@@ -1,0 +1,112 @@
+{% comment %}
+
+Remove the third paragraph if the workshop will teach Python
+using something other than the Jupyter Notebook. Details at
+
+https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatibility
+{% endcomment %}
+<div id="python">
+
+  <p>
+    <a href="https://python.org">Python</a> is a popular language for
+    research computing, and great for general-purpose programming as
+    well. Installing all of its research packages individually can be
+    a bit difficult, so we recommend
+    <a href="https://www.anaconda.com/products/individual">Anaconda</a>,
+    an all-in-one installer.
+  </p>
+
+  <p>
+    Regardless of how you choose to install it,
+    <strong>please make sure you install Python version 3.x</strong>
+    (e.g., 3.6 is fine).
+  </p>
+
+  {% comment %}
+  Please remove or comment out this paragraph using
+  <!-- and --> or  {% comment %} and {% endcomment %}
+  if you do not plan to use Jupyter Notebook environment.
+  {% endcomment %}
+  <p>
+    We will teach Python using the <a href="https://jupyter.org/">Jupyter Notebook</a>,
+    a programming environment that runs in a web browser (Jupyter Notebook will be installed by Anaconda). For this to work you will need a reasonably
+    up-to-date browser. The current versions of the Chrome, Safari and
+    Firefox browsers are all
+    <a href="https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatibility">supported</a>
+    (some older browsers, including Internet Explorer version 9
+    and below, are not).
+  </p>
+
+  <div>
+    <ul class="nav nav-tabs" role="tablist">
+      <li role="presentation" class="active"><a data-os="windows" href="#python-windows" aria-controls="Windows" role="tab" data-toggle="tab">Windows</a></li>
+      <li role="presentation"><a data-os="macos" href="#python-macos" aria-controls="MacOS" role="tab" data-toggle="tab">MacOS</a></li>
+      <li role="presentation"><a data-os="linux" href="#python-linux" aria-controls="Linux" role="tab" data-toggle="tab">Linux</a></li>
+    </ul>
+
+    <div class="tab-content">
+      <article role="tabpanel" class="tab-pane active" id="python-windows">
+        <ol>
+          <li>Open <a href="https://www.anaconda.com/products/individual#download-section">https://www.anaconda.com/products/individual#download-section</a> with your web browser.</li>
+          <li>Download the Anaconda for Windows installer with Python 3. (If you are not sure which version to choose, you probably want the 64-bit Graphical Installer <em>Anaconda3-...-Windows-x86_64.exe</em>)</li>
+          <li>Install Python 3 by running the Anaconda Installer, using all of the defaults for installation <em>except</em> make sure to check <strong>Add Anaconda to my PATH environment variable</strong>.</li>
+        </ol>
+        <h4>Video Tutorial</h4>
+        <div class="yt-wrapper2">
+        <div class="yt-wrapper">
+        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/xxQ0mzZ8UvA?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
+        </div>
+        </div>
+      </article>
+      <article role="tabpanel" class="tab-pane" id="python-macos">
+        <ol>
+          <li>Open <a href="https://www.anaconda.com/products/individual#download-section">https://www.anaconda.com/products/individual#download-section</a> with your web browser.</li>
+          <li>Download the Anaconda Installer with Python 3 for macOS (you can either use the Graphical or the Command Line Installer).</li>
+          <li>Install Python 3 by running the Anaconda Installer using all of the defaults for installation.</li>
+        </ol>
+        <h4>Video Tutorial</h4>
+        <div class="yt-wrapper2">
+        <div class="yt-wrapper">
+        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/TcSAln46u9U?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
+        </div>
+        </div>
+      </article>
+      <article role="tabpanel" class="tab-pane" id="python-linux">
+        <ol>
+          <li>Open <a href="https://www.anaconda.com/products/individual#download-section">https://www.anaconda.com/products/individual#download-section</a> with your web browser.</li>
+          <li>Download the Anaconda Installer with Python 3 for Linux.<br>
+            (The installation requires using the shell. If you aren't
+            comfortable doing the installation yourself
+            stop here and request help at the workshop.)
+          </li>
+          <li>
+            Open a terminal window and navigate to the directory where
+            the executable is downloaded (e.g., `cd ~/Downloads`).
+          </li>
+          <li>
+            Type <pre>bash Anaconda3-</pre> and then press
+            <kbd>Tab</kbd> to autocomplete the full file name. The name of
+            file you just downloaded should appear.
+          </li>
+          <li>
+            Press <kbd>Enter</kbd>
+            (or <kbd>Return</kbd> depending on your keyboard).
+            You will follow the text-only prompts.
+            To move through the text, press <kbd>Spacebar</kbd>.
+            Type <code>yes</code> and press enter to approve the license.
+            Press <kbd>Enter</kbd> (or <kbd>Return</kbd>)
+            to approve the default location
+            for the files.
+            Type <code>yes</code> and press
+            <kbd>Enter</kbd> (or <kbd>Return</kbd>)
+            to prepend Anaconda to your <code>PATH</code>
+            (this makes the Anaconda distribution the default Python).
+          </li>
+          <li>
+            Close the terminal window.
+          </li>
+        </ol>
+      </article>
+    </div>
+  </div>
+</div>

--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -10,11 +10,13 @@ $color-brand:       #2b3990 !default;
 
 // code boxes
 $color-error:       #bd2c00 !default;
+$color-warning:     #cda01d !default;
 $color-output:      #303030 !default;
-$color-source:      #6e5494 !default;
+$color-source:      #360084 !default;
 
 // blockquotes
 $color-callout:     #f4fd9c !default;
+$color-caution:     #cf000e !default;
 $color-challenge:   #eec275 !default;
 $color-checklist:   #dfd2a0 !default;
 $color-discussion:  #eec275 !default;
@@ -30,48 +32,93 @@ $color-testimonial: #fc8dc1 !default;
 
 @mixin cdSetup($color) {
     color: $color;
-    border: solid 0.5px $color;
+    border: solid 1px $color;
     border-left: solid 5px $color;
     margin: 15px 5px 10px 0;
     border-radius: 4px 0 0 4px;
 }
 
-.error  { @include cdSetup($color-error); }
-.output { @include cdSetup($color-output); }
-.source { @include cdSetup($color-source); }
+// Generic setup. Has to come before .error, .warning, and .output
+div[class^='language-'] { @include cdSetup($color-source); }
 
-.bash, .language-bash     { @include cdSetup($color-source); }
-.make, .language-make     { @include cdSetup($color-source); }
-.matlab, .language-matlab { @include cdSetup($color-source); }
-.python, .language-python { @include cdSetup($color-source); }
-.r, .language-r           { @include cdSetup($color-source); }
-.sql, .language-sql       { @include cdSetup($color-source); }
+div.source  { @include cdSetup($color-source); }
+div.error   { @include cdSetup($color-error); }
+div.warning { @include cdSetup($color-warning); }
+div.output  { @include cdSetup($color-output); }
 
-.error::before,
-.output::before,
-.source::before,
-.bash::before, .language-bash::before,
-.make::before, .language-make::before,
-.matlab::before, .language-matlab::before,
-.python::before, .language-python::before,
-.r::before, .language-r::before,
-.sql::before, .language-sql::before {
-  background-color: #f2eff6;
-  display: block;
-  font-weight: bold;
-  padding: 5px 10px;
+div.error::before,
+div.warning:before,
+div.output::before,
+div.source::before,
+div[class^='language-']::before {
+    background-color: #f2eff6;
+    display: block;
+    font-weight: bold;
+    padding: 5px 10px;
 }
 
-.error::before  { background-color: #ffebe6; content: "Error"; }
-.output::before { background-color: #efefef; content: "Output"; }
-.source::before { content: "Code"; }
-.bash::before, .language-bash::before { content: "Bash"; }
-.make::before, .language-make::before { content: "Make"; }
-.matlab::before, .language-matlab::before { content: "Matlab"; }
-.python::before, .language-python::before { content: "Python"; }
-.r::before, .language-r::before { content: "R"; }
-.sql::before, .language-sql::before { content: "SQL"; }
+div[class^='language-']::before,
+div.source::before { content: "Code"; }
 
+div.error::before  { background-color: #ffebe6; content: "Error"; }
+div.warning:before { background-color: #f8f4e8; content:" Warning"; }
+div.output::before { background-color: #efefef; content: "Output"; }
+
+div.language-bash::before   { content: "Bash"; }
+div.language-c::before      { content: "C"; }
+div.language-cmake::before  { content: "CMake"; }
+div.language-cpp::before    { content: "C++"; }
+div.language-html::before   { content: "HTML"; }
+div.language-make::before   { content: "Make"; }
+div.language-matlab::before { content: "MATLAB"; }
+div.language-python::before { content: "Python"; }
+div.language-r::before      { content: "R"; }
+div.language-sql::before    { content: "SQL"; }
+
+// Tab panels are used on Setup pages to show instructions for different Operating Systems
+.tab-pane {
+  border: solid 1px #ddd; // #ddd == @nav-tabs-active-link-hover-border-color
+  border-top: none;
+  padding: 20px 20px 10px 20px;
+  border-radius: 0 0 4px 4px; // 4px == @border-radius-base
+}
+
+// Stripe above tab panels where OS tabs are shown
+ul.nav.nav-tabs {
+  background: #E1E1E1;
+  border-radius: 4px 4px 0 0;  // 4px == @border-radius-base
+}
+
+// adjust line height of links so that clickable area (of OS tabs) is 44px high
+ul.nav.nav-tabs li a { line-height: 24px; } // or 1.714285716
+
+// This color provides better contrast ratio on most backgrounds used on Carpentries websites
+// 9.24 on FFFFFF: https://webaim.org/resources/contrastchecker/?fcolor=204A6F&bcolor=FFFFFF&api (body)
+// 8.78 on F9F9F9: https://webaim.org/resources/contrastchecker/?fcolor=204A6F&bcolor=F9F9F9&api (tables)
+// 7.07 on E1E1E1: https://webaim.org/resources/contrastchecker/?fcolor=204A6F&bcolor=E1E1E1&api (tab panels)
+a { color: #204A6F; }
+
+// .yt-wrapper2 can be used for limiting maximum width of YouTube iframes only
+.yt-wrapper2 { max-width: 100%; margin: 0 auto; }
+
+// Use full width on small displays
+@media only screen and (max-width: 600px) { .yt-wrapper2 { max-width: 100%; } }
+
+.yt-wrapper {
+    height: 0;
+    margin-top: 10px;
+    padding-bottom: 56.25%;
+    position: relative;
+    width: 100%;
+}
+
+.yt-frame {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+}
 
 //----------------------------------------
 // Specialized blockquote environments for learning objectives, callouts, etc.
@@ -113,6 +160,7 @@ $codeblock-padding: 5px !default;
 }
 
 .callout{ @include bkSetup($color-callout, "\e146"); }
+.caution{ @include bkSetup($color-caution, "\e107"); }
 .challenge{ @include bkSetup($color-challenge, "\270f"); }
 .checklist{ @include bkSetup($color-checklist, "\e067"); }
 .discussion{ @include bkSetup($color-discussion, "\e123"); }
@@ -148,17 +196,45 @@ font-size: 18px;
 blockquote p {
     margin: 5px;
 }
+blockquote :not(h2) + p {
+    padding-top: 1em;
+}
 
 //----------------------------------------
 // Override Bootstrap settings.
 //----------------------------------------
 
+blockquote { font-size: inherit; }
+
+a code {
+  color: #006cad;
+}
+
+a:link {
+  color: #196EBD;
+}
+
+a:active,
+a:hover {
+  outline: 0;
+  text-decoration: underline;
+}
+
+a:visited {
+  color: #1AA4DA;
+}
+
 code {
   white-space: nowrap;
   padding: 2px 5px;
-  color: #006cad;
+  color: #24292e;
   background-color: #e7e7e7;
 }
+
+samp { hyphens: none; }
+
+dt { margin-top: 20px; }
+dd { margin-left: 2em; }
 
 article img {
     display: block;
@@ -194,7 +270,7 @@ article pre {
   text-align: center;
 }
 
-footer .copyright,
+footer .license,
 footer .help-links
 {
     font-size: inherit;
@@ -253,6 +329,12 @@ div.life-cycle {
 .beta {
     color: #31708f;
     background: #d9edf7;
+}
+
+// Remove border around spans of text within code blocks
+// that the highlighter (rouge) failed to recognize.
+pre.highlight span.err {
+    border: none;
 }
 
 

--- a/setup.md
+++ b/setup.md
@@ -2,69 +2,6 @@
 title: "Setup"
 ---
 
-## Installing Python Using Anaconda
-
-[Python][python] is a popular language for scientific computing, and great for
-general-purpose programming as well. Installing all of its scientific packages
-individually can be a bit difficult, however, so we recommend the all-in-one
-installer [Anaconda][anaconda].
-
-Regardless of how you choose to install it, please make sure you install Python
-version 3.x (e.g., 3.4 is fine). Also, please set up your python environment at
-least a day in advance of the workshop.  If you encounter problems with the
-installation procedure, ask your workshop organizers via e-mail for assistance so
-you are ready to go as soon as the workshop begins.
-
-### Windows - [Video tutorial][video-windows]
-
-1. Open [https://www.anaconda.com/distribution/][anaconda-windows] with your web browser.
-
-2. Download the Python 3 installer for Windows.
-
-3. Double-click the executable and install Python 3 using the recommended settings. Make sure that **Register Anaconda as my default Python 3.x** option is checked - it should be in the latest version of Anaconda
-
-### Mac OS X - [Video tutorial][video-mac]
-
-1. Visit [https://www.anaconda.com/distribution/][anaconda-mac] with your web browser.
-
-2. Download the Python 3 installer for OS X. These instructions assume that you use the graphical installer `.pkg` file.
-
-3. Follow the Python 3 installation instructions. Make sure that the install location is set to "Install only for me" so Anaconda will install its files locally, relative to your home directory. Installing the software for all users tends to create problems in the long run and should be avoided.
-
-
-### Linux
-
-Note that the following installation steps require you to work from the shell.
-If you run into any difficulties, please request help before the workshop begins.
-
-1.  Open [https://www.anaconda.com/distribution/][anaconda-linux] with your web browser.
-
-2.  Download the Python 3 installer for Linux.
-
-3.  Install Python 3 using all of the defaults for installation.
-
-    a.  Open a terminal window.
-
-    b.  Navigate to the folder where you downloaded the installer
-
-    c.  Type
-
-    ~~~
-    $ bash Anaconda3-
-    ~~~
-    {: .bash}
-
-    and press tab.  The name of the file you just downloaded should appear.
-
-    d.  Press enter.
-
-    e.  Follow the text-only prompts.  When the license agreement appears (a colon
-        will be present at the bottom of the screen) press the space bar until you see the
-        bottom of the text. Type `yes` and press enter to approve the license. Press
-        enter again to approve the default location for the files. Type `yes` and
-        press enter to prepend Anaconda to your `PATH` (this makes the Anaconda
-        distribution your user's default Python).
-
 ## Getting the Data
 
 The data we will be using is taken from the [gapminder][gapminder] dataset.
@@ -73,6 +10,11 @@ To obtain it, download and unzip the file
 In order to follow the presented material, you should launch the JupyterLab
 server in the root directory (see [Starting JupyterLab]({{ page.root }}/01-run-quit/#starting-jupyterlab)).
 
+## Installing Python Using Anaconda
+
+{% include python_install.html %}
+
+<br>
 
 [anaconda]: https://www.anaconda.com/
 [anaconda-mac]: https://www.anaconda.com/download/#macos


### PR DESCRIPTION
Hi,

Please see #501 for discussion.

If merged, this PR will:
- Add the `_includes/python_install.html` file with setup instructions, the same present in [carpentries/workshop-template](https://github.com/carpentries/workshop-template/blob/gh-pages/_includes/install_instructions/python.html) repository. This file contains embedded video instructions for each operating system.
- Include said file in the `setup.md` (and delete previous instructions). I also moved the "Getting the Data Section" up so it does not stay hidden below the Python setup section.
- Update the `assets/css/lesson.scss` file according to the [carpentries/workshop-template](https://github.com/carpentries/workshop-template/blob/gh-pages/assets/css/lesson.scss) repository.

I do know that altering static files may be a bit risky, but that was needed so the Python setup instructions block would look right. I rendered the lesson locally on OS X and could not find any problems.

Best,
V