### PR TITLE
Remove matplotlib inline magic

### DIFF
--- a/_episodes/09-plotting.md
+++ b/_episodes/09-plotting.md
@@ -18,11 +18,9 @@ keypoints:
 ## [`matplotlib`](https://matplotlib.org/) is the most widely used scientific plotting library in Python.
 
 *   Commonly use a sub-library called [`matplotlib.pyplot`](https://matplotlib.org/api/pyplot_api.html).
-*   The Jupyter Notebook will render plots inline if we ask it to using a "magic" command, which have a `%` character
-preceding them.
+*   The Jupyter Notebook will render plots inline by default.
 
 ~~~
-%matplotlib inline
 import matplotlib.pyplot as plt
 ~~~
 {: .language-python}
@@ -43,7 +41,7 @@ plt.ylabel('Position (km)')
 
 > ## Display All Open Figures
 > 
-> In our Jupyter Notebook example with `%matplotlib inline`, running the cell generates the figure directly below the code. 
+> In our Jupyter Notebook example, running the cell should generate the figure directly below the code. 
 > The figure is also included in the Notebook document for future viewing.
 > However, other Python environments require an additional command in order to display the figure.
 >

--- a/_episodes/09-plotting.md
+++ b/_episodes/09-plotting.md
@@ -43,7 +43,8 @@ plt.ylabel('Position (km)')
 > 
 > In our Jupyter Notebook example, running the cell should generate the figure directly below the code. 
 > The figure is also included in the Notebook document for future viewing.
-> However, other Python environments require an additional command in order to display the figure.
+> However, other Python environments, such as when running Python directly from a terminal window,
+> require an additional command in order to display the figure.
 >
 > Instruct `matplotlib` to show a figure:
 > ~~~

--- a/_episodes/09-plotting.md
+++ b/_episodes/09-plotting.md
@@ -43,8 +43,8 @@ plt.ylabel('Position (km)')
 > 
 > In our Jupyter Notebook example, running the cell should generate the figure directly below the code. 
 > The figure is also included in the Notebook document for future viewing.
-> However, other Python environments, such as when running Python directly from a terminal window,
-> require an additional command in order to display the figure.
+> However, other Python environments like an interactive Python session started from a terminal 
+> or a Python script executed via the command line require an additional command to display the figure.
 >
 > Instruct `matplotlib` to show a figure:
 > ~~~


### PR DESCRIPTION
Running `%matplotlib inline` is no longer necessary when we want to directly display figures in a Jupyter notebook. This has been the default behaviour of Jupyter for several years, since a few versions ago.

There are no mentions of "magic" commands elsewhere in this lesson, so I feel it would be quite confusing if not properly explained, and would be a loss of time if explained in detail (since I would also argue that these later episodes should be more about python than about IPython).