### PR TITLE
Replace Jupyter Notebook with JupyterLab in Setup page

### DIFF
--- a/_includes/python_install.html
+++ b/_includes/python_install.html
@@ -1,9 +1,9 @@
 {% comment %}
 
 Remove the third paragraph if the workshop will teach Python
-using something other than the Jupyter Notebook. Details at
+using something other than the JupyterLab. Details at
 
-https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatibility
+https://jupyterlab.readthedocs.io/en/latest/getting_started/installation.html#supported-browsers
 {% endcomment %}
 <div id="python">
 
@@ -25,14 +25,14 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
   {% comment %}
   Please remove or comment out this paragraph using
   <!-- and --> or  {% comment %} and {% endcomment %}
-  if you do not plan to use Jupyter Notebook environment.
+  if you do not plan to use JupyterLab environment.
   {% endcomment %}
   <p>
-    We will teach Python using the <a href="https://jupyter.org/">Jupyter Notebook</a>,
-    a programming environment that runs in a web browser (Jupyter Notebook will be installed by Anaconda). For this to work you will need a reasonably
+    We will teach Python using the <a href="https://jupyter.org/">JupyterLab</a>,
+    a programming environment that runs in a web browser (JupyterLab will be installed by Anaconda). For this to work you will need a reasonably
     up-to-date browser. The current versions of the Chrome, Safari and
     Firefox browsers are all
-    <a href="https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatibility">supported</a>
+    <a href="https://jupyterlab.readthedocs.io/en/latest/getting_started/installation.html#supported-browsers">supported</a>
     (some older browsers, including Internet Explorer version 9
     and below, are not).
   </p>


### PR DESCRIPTION
Issue 397 explains how Jupyter Notebook was replaced with JupyterLab throughout this lesson. The setup page was not updated. https://github.com/swcarpentry/python-novice-gapminder/issues/397
I've made some suggestions here including links to docs. Please check them carefully, I'm not sure if these changes are correct or necessary.

Perhaps the docs links should go to 'stable' rather than 'latest' in my code suggestion?