### PR TITLE
Update 03-types-conversion.md

### DIFF
--- a/_episodes/03-types-conversion.md
+++ b/_episodes/03-types-conversion.md
@@ -192,10 +192,10 @@ three squared is 9.0
 *   This does **not** happen in programming languages.
 
 ~~~
-first = 1
-second = 5 * first
-first = 2
-print('first is', first, 'and second is', second)
+variable_one = 1
+variable_two = 5 * variable_one
+variable_one = 2
+print('first is', variable_one, 'and second is', variable_two)
 ~~~
 {: .language-python}
 ~~~
@@ -427,9 +427,9 @@ first is 2 and second is 5
 > as `val.real` and `val.imag`.
 >
 > ~~~
-> complex = 6 + 2j
-> print(complex.real)
-> print(complex.imag)
+> v_comp = 6 + 2j
+> print(v_comp.real)
+> print(v_comp.imag)
 > ~~~
 > {: .language-python}
 >


### PR DESCRIPTION
Feedback from a workshop recently was that using 'first' and 'second' for variable names was confusing "especially when you have to say things like “the first value of ‘first’ is … and the second value of ‘second’ is …”. This change is to suggest changing those variable names to 'variable_one' and 'variable_two'. Maybe alternatively x and y, or v1 and v2 - basically anything other than first and second! 

Similarly, I suggest renaming the variable 'complex' - again this caused confusion with the variable name being the same as the type name.

Thanks :-)

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
