### PR TITLE
Add example for failing type conversion

### DIFF
--- a/_episodes/03-types-conversion.md
+++ b/_episodes/03-types-conversion.md
@@ -168,6 +168,22 @@ print(str(1) + '2')
 ~~~
 {: .output}
 
+* This is not possible for every value 
+
+~~~
+print(int('Ahmed'))
+~~~
+{: .language-python}
+~~~
+---------------------------------------------------------------------------
+ValueError                                Traceback (most recent call last)
+<ipython-input-21-934e1d57e2db> in <module>
+----> 1 print(int('Ahmed'))
+
+ValueError: invalid literal for int() with base 10: 'Ahmed'
+~~~
+{: .error}
+
 ## Can mix integers and floats freely in operations.
 
 *   Integers and floating-point numbers can be mixed in arithmetic.


### PR DESCRIPTION
Added an example where the type conversion from str to int fails for illutrative purposes. It is a common error and it is good for beginners to see it explicitly.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
