### PR TITLE
Clarify explanation of "How Large is a Slice?"

### DIFF
--- a/_episodes/11-lists.md
+++ b/_episodes/11-lists.md
@@ -236,14 +236,14 @@ IndexError: string index out of range
 
 > ## How Large is a Slice?
 >
-> If `low` and `high` are both non-negative integers,
-> how long is the list `values[low:high]`?
+> If `start` and `stop` are both non-negative integers,
+> how long is the list `values[start:stop]`?
 >
 > > ## Solution
-> > The list `values[low:high]` has up to `high - low` elements.  For example,
+> > The list `values[start:stop]` has up to `stop - start` elements.  For example,
 > > `values[1:4]` has the 3 elements `values[1]`, `values[2]`, and `values[3]`.
 > > Why 'up to'? As we saw in [episode 2]({{ page.root }}/02-variables/),
-> > if `high` is larger than the total length of the list `values`,
+> > if `stop` is greater than the total length of the list `values`,
 > > we will still get a list back but it will be shorter than expected.
 > {: .solution}
 {: .challenge}

--- a/_episodes/11-lists.md
+++ b/_episodes/11-lists.md
@@ -236,14 +236,15 @@ IndexError: string index out of range
 
 > ## How Large is a Slice?
 >
-> If 'low' and 'high' are both non-negative integers,
+> If `low` and `high` are both non-negative integers,
 > how long is the list `values[low:high]`?
 >
 > > ## Solution
-> > The list `values[low:high]` has `high - low` elements.  For example,
+> > The list `values[low:high]` has up to `high - low` elements.  For example,
 > > `values[1:4]` has the 3 elements `values[1]`, `values[2]`, and `values[3]`.
-> > Note that the expression will only work if `high` is less than the total
-> > length of the list `values`.
+> > Why 'up to'? As we saw in [episode 2]({{ page.root }}/02-variables/),
+> > if `high` is larger than the total length of the list `values`,
+> > we will still get a list back but it will be shorter than expected.
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
The solution for "How Large is a Slice?" says the the expression `values[low:high]`, or possibly `high - low`, will only work if `high` is less than the total length of the list `values`. This isn't quite correct on either interpretation.

As shown in Episode 2, `values[low:high]` will always return a list, even if one or both of the limits are out of bounds. The length of the slice will be `high - low` if and only if `high` is equal to or less than the length of the list; it will be zero if both `high` and `low` are greater than the length of the list, and somewhere in between otherwise.

This pull request suggests alternative wording that I think would be clearer and more accurate.