### PR TITLE
Clean indentation in 16-writing-functions

### DIFF
--- a/_episodes/16-writing-functions.md
+++ b/_episodes/16-writing-functions.md
@@ -360,16 +360,16 @@ result of call is: None
 >     mass = 70 + 20.0 * (2.0 * random.random() - 1.0)
 >
 >     print(mass)
->    
+>
 >     # egg sizing machinery prints a label
 >     if mass >= 85:
->        print("jumbo")
+>         print("jumbo")
 >     elif mass >= 70:
->        print("large")
+>         print("large")
 >     elif mass < 70 and mass >= 55:
->        print("medium")
+>         print("medium")
 >     else:
->        print("small")
+>         print("small")
 > ~~~
 > {: .language-python}
 >
@@ -433,24 +433,24 @@ result of call is: None
 > 1. Complete the statements below to obtain the average GDP for Japan
 >    across the years reported for the 1980s.
 >
->     ~~~
->     year = 1983
->     gdp_decade = 'gdpPercap_' + str(year // ____)
->     avg = (japan.loc[gdp_decade + ___] + japan.loc[gdp_decade + ___]) / 2
->     ~~~
->     {: .language-python}
+>    ~~~
+>    year = 1983
+>    gdp_decade = 'gdpPercap_' + str(year // ____)
+>    avg = (japan.loc[gdp_decade + ___] + japan.loc[gdp_decade + ___]) / 2
+>    ~~~
+>    {: .language-python}
 >
 > 2. Abstract the code above into a single function.
 >
->     ~~~
->     def avg_gdp_in_decade(country, continent, year):
->         df = pd.read_csv('data/gapminder_gdp_'+___+'.csv',delimiter=',',index_col=0)
->         ____
->         ____
->         ____
->         return avg
->     ~~~
->     {: .language-python}
+>    ~~~
+>    def avg_gdp_in_decade(country, continent, year):
+>        df = pd.read_csv('data/gapminder_gdp_'+___+'.csv',delimiter=',',index_col=0)
+>        ____
+>        ____
+>        ____
+>        return avg
+>    ~~~
+>    {: .language-python}
 >
 > 3. How would you generalize this function
 >    if you did not know beforehand which specific years occurred as columns in the data?
@@ -462,41 +462,41 @@ result of call is: None
 > >
 > > 1. The average GDP for Japan across the years reported for the 1980s is computed with:
 > >
-> >     ~~~
-> >     year = 1983
-> >     gdp_decade = 'gdpPercap_' + str(year // 10)
-> >     avg = (japan.loc[gdp_decade + '2'] + japan.loc[gdp_decade + '7']) / 2
-> >     ~~~
-> >     {: .language-python}
+> >    ~~~
+> >    year = 1983
+> >    gdp_decade = 'gdpPercap_' + str(year // 10)
+> >    avg = (japan.loc[gdp_decade + '2'] + japan.loc[gdp_decade + '7']) / 2
+> >    ~~~
+> >    {: .language-python}
 > >
 > > 2. That code as a function is:
 > >
-> >     ~~~
-> >     def avg_gdp_in_decade(country, continent, year):
-> >         df = pd.read_csv('data/gapminder_gdp_' + continent + '.csv', index_col=0)
-> >         c = df.loc[country]
-> >         gdp_decade = 'gdpPercap_' + str(year // 10)
-> >         avg = (c.loc[gdp_decade + '2'] + c.loc[gdp_decade + '7'])/2
-> >         return avg
-> >     ~~~
-> >     {: .language-python}
+> >    ~~~
+> >    def avg_gdp_in_decade(country, continent, year):
+> >        df = pd.read_csv('data/gapminder_gdp_' + continent + '.csv', index_col=0)
+> >        c = df.loc[country]
+> >        gdp_decade = 'gdpPercap_' + str(year // 10)
+> >        avg = (c.loc[gdp_decade + '2'] + c.loc[gdp_decade + '7'])/2
+> >        return avg
+> >    ~~~
+> >    {: .language-python}
 > >
 > > 3. To obtain the average for the relevant years, we need to loop over them:
 > >
 > >    ~~~
 > >    def avg_gdp_in_decade(country, continent, year):
-> >         df = pd.read_csv('data/gapminder_gdp_' + continent + '.csv', index_col=0)
-> >         c = df.loc[country]
-> >         gdp_decade = 'gdpPercap_' + str(year // 10)
-> >         total = 0.0
-> >         num_years = 0
-> >         for yr_header in c.index: # c's index contains reported years
-> >             if yr_header.startswith(gdp_decade):
-> >                 total = total + c.loc[yr_header]
-> >                 num_years = num_years + 1
-> >         return total/num_years
-> >     ~~~
-> >     {: .language-python}
+> >        df = pd.read_csv('data/gapminder_gdp_' + continent + '.csv', index_col=0)
+> >        c = df.loc[country]
+> >        gdp_decade = 'gdpPercap_' + str(year // 10)
+> >        total = 0.0
+> >        num_years = 0
+> >        for yr_header in c.index: # c's index contains reported years
+> >            if yr_header.startswith(gdp_decade):
+> >                total = total + c.loc[yr_header]
+> >                num_years = num_years + 1
+> >        return total/num_years
+> >    ~~~
+> >    {: .language-python}
 > >
 > > The function can now be called by:
 > >


### PR DESCRIPTION
Some Python code snippets in episode 16 are exhibiting odd indentation levels (1, 3, 5 spaces). This pull request restores the originally intended indentation (multiples of 4 spaces).