### PR TITLE
Remove unexplained augmented assignment operators from examples

### DIFF
--- a/_episodes/12-for-loops.md
+++ b/_episodes/12-for-loops.md
@@ -322,7 +322,7 @@ print(total)
 > cumulative.append(total)
 > for number in data:
 > cumulative = []
-> total += number
+> total = total + number
 > total = 0
 > print(cumulative)
 > data = [1,2,2,5]
@@ -334,7 +334,7 @@ print(total)
 > > data = [1,2,2,5]
 > > cumulative = []
 > > for number in data:
-> >     total += number
+> >     total = total + number
 > >     cumulative.append(total)
 > > print(cumulative)
 > > ~~~

--- a/_episodes/18-style.md
+++ b/_episodes/18-style.md
@@ -167,8 +167,8 @@ average(values)
 >     for j in range(len(s)):
 >         left = j-1
 >         right = (j+1)%len(s)
->         if s[left]==s[right]: new += '-'
->         else: new += '*'
+>         if s[left]==s[right]: new = new + '-'
+>         else: new = new + '*'
 >     s=''.join(new)
 >     print(s)
 >     i += 1
@@ -197,9 +197,9 @@ average(values)
 > >             left = j-1
 > >             right = (j+1) % input_string_length  # ensure right index wraps around
 > >             if old[left] == old[right]:
-> >                 new += '-'
+> >                 new = new + '-'
 > >             else:
-> >                 new += '*'
+> >                 new = new + '*'
 > >         print(new)
 > >         # store new string as old
 > >         old = new     


### PR DESCRIPTION
Resolves #582 per issue discussion.

I did leave _one_ instance of `+=` in the exercise in episode 18, since its point was to emphasize the value of readable rather than terse code and I feel that running into unfamiliar syntax in the wild is a pretty common experience with codebases that need refactoring. Happy to remove it for overall consistency, though.

