### PR TITLE
Fix JupyterLab link in index.md (#594)

### DIFF
--- a/_includes/links.md
+++ b/_includes/links.md
@@ -19,7 +19,7 @@
 [jekyll-windows]: http://jekyll-windows.juthilo.com/
 [jekyll]: https://jekyllrb.com/
 [jupyter]: https://jupyter.org/
-[juptyerlab]: https://jupyter.org/
+[jupyterlab]: https://jupyter.org/
 [kramdown]: https://kramdown.gettalong.org/
 [lc-lessons]: https://librarycarpentry.org/lessons/
 [lesson-aio]: {{ relative_root_path }}{% link aio.md %}


### PR DESCRIPTION
Repeated link to jupyter.org for JupyterLab in links.md to address #594. Sorry for the messy PR with three commits when one would've sufficed (not sure how to clean it up).
