### PR TITLE
minor changes to 08-data-frames

### DIFF
--- a/_episodes/08-data-frames.md
+++ b/_episodes/08-data-frames.md
@@ -56,7 +56,7 @@ print(data.iloc[0, 0])
 
 ## Use `DataFrame.loc[..., ...]` to select values by their (entry) label.
 
-*   Can specify location by row name analogously to 2D version of dictionary keys.
+*   Can specify location by row and/or column name.
 
 ~~~
 print(data.loc["Albania", "gdpPercap_1952"])


### PR DESCRIPTION
Commit 1 adds print statements on 2 lines of code:
To be consistent with the rest of the episode's code, the dataframes in question should be printed explicitly.
Leaving out the print statement suggests that this would also work outside of the jupyter environment. 

Commit 2 changes the explanation of the .loc method:
1. dictionaries were not explained yet in this lesson; I deleted that part
2. location can be specified by column names as well; I've added that information