### PR TITLE
Change order of line 327 and 328 - Lesson Contribution

### DIFF
--- a/_episodes/09-plotting.md
+++ b/_episodes/09-plotting.md
@@ -324,8 +324,8 @@ data.T.plot.scatter(x = 'Australia', y = 'New Zealand')
 > * call the `savefig` class method from that variable.
 >
 > ~~~
-> fig = plt.gcf() # get current figure
 > data.plot(kind='bar')
+> fig = plt.gcf() # get current figure
 > fig.savefig('my_figure.png')
 > ~~~
 > {: .language-python}


### PR DESCRIPTION
I'm a member of The Carpentries Core Team and I'm submitting this issue on behalf of another member of the community. In most cases, I won't be able to follow up or provide more details other than what I'm providing below.

---

Swap the order of lines 327 (fig = plt.gcf() # get current figure) and 328 (data.plot(kind='bar'). This will then correctly save the bar plot as the last global plot. Currently, this code does not save and generates an empty plot file.
