### PR TITLE
improve dataframe naming conventions

### DIFF
--- a/_episodes/07-reading-tabular.md
+++ b/_episodes/07-reading-tabular.md
@@ -22,16 +22,16 @@ keypoints:
 *   Borrows many features from R's dataframes.
     *   A 2-dimensional table whose columns have names
         and potentially have different data types.
-*   Load it with `import pandas as pd`. The alias pd is commonly used for Pandas.
+*   Load Pandas with `import pandas as pd`. The alias `pd` is commonly used to refer to the Pandas library in code.
 *   Read a Comma Separated Values (CSV) data file with `pd.read_csv`.
     *   Argument is the name of the file to be read.
-    *   Assign result to a variable to store the data that was read.
+    *   Returns a dataframe that you can assign to a variable 
 
 ~~~
 import pandas as pd
 
-data = pd.read_csv('data/gapminder_gdp_oceania.csv')
-print(data)
+data_oceania = pd.read_csv('data/gapminder_gdp_oceania.csv')
+print(data_oceania)
 ~~~
 {: .language-python}
 ~~~
@@ -55,6 +55,7 @@ print(data)
 
 *   The columns in a dataframe are the observed variables, and the rows are the observations.
 *   Pandas uses backslash `\` to show wrapped lines when output is too wide to fit the screen.
+*   Using descriptive dataframe names helps us distinguish between multiple dataframes so we won't accidentally overwrite a dataframe or read from the wrong one.
 
 > ## File Not Found
 >
@@ -76,10 +77,11 @@ print(data)
 *   Row headings are numbers (0 and 1 in this case).
 *   Really want to index by country.
 *   Pass the name of the column to `read_csv` as its `index_col` parameter to do this.
+*   Naming the dataframe `data_oceania_country` tells us which region the data includes (`oceania`) and how it is indexed (`country`).
 
 ~~~
-data = pd.read_csv('data/gapminder_gdp_oceania.csv', index_col='country')
-print(data)
+data_oceania_country = pd.read_csv('data/gapminder_gdp_oceania.csv', index_col='country')
+print(data_oceania_country)
 ~~~
 {: .language-python}
 ~~~
@@ -103,7 +105,7 @@ New Zealand     18363.32494     21050.41377     23189.80135     25185.00911
 ## Use the `DataFrame.info()` method to find out more about a dataframe.
 
 ~~~
-data.info()
+data_oceania_country.info()
 ~~~
 {: .language-python}
 ~~~
@@ -141,7 +143,7 @@ memory usage: 208.0+ bytes
 *   Called a *member variable*, or just *member*.
 
 ~~~
-print(data.columns)
+print(data_oceania_country.columns)
 ~~~
 {: .language-python}
 ~~~
@@ -159,7 +161,7 @@ Index(['gdpPercap_1952', 'gdpPercap_1957', 'gdpPercap_1962', 'gdpPercap_1967',
 *   Like `columns`, it is a member variable.
 
 ~~~
-print(data.T)
+print(data_oceania_country.T)
 ~~~
 {: .language-python}
 ~~~
@@ -184,7 +186,7 @@ gdpPercap_2007  34435.36744  25185.00911
 `DataFrame.describe()` gets the summary statistics of only the columns that have numerical data. 
 All other columns are ignored, unless you use the argument `include='all'`.
 ~~~
-print(data.describe())
+print(data_oceania_country.describe())
 ~~~
 {: .language-python}
 ~~~
@@ -227,7 +229,7 @@ max      23424.766830    26997.936570    30687.754730    34435.367440
 >
 > Read the data in `gapminder_gdp_americas.csv`
 > (which should be in the same directory as `gapminder_gdp_oceania.csv`)
-> into a variable called `americas`
+> into a variable called `data_americas`
 > and display its summary statistics.
 >
 > > ## Solution
@@ -235,8 +237,8 @@ max      23424.766830    26997.936570    30687.754730    34435.367440
 > > We also once again pass the column name `'country'` to the parameter `index_col` in order to index by country.
 > > The summary statistics can be displayed with the `DataFrame.describe()` method.
 > > ~~~
-> > americas = pd.read_csv('data/gapminder_gdp_americas.csv', index_col='country')
-> > americas.describe()
+> > data_americas = pd.read_csv('data/gapminder_gdp_americas.csv', index_col='country')
+> > data_americas.describe()
 > > ~~~
 > >{: .language-python}
 > {: .solution}
@@ -245,7 +247,7 @@ max      23424.766830    26997.936570    30687.754730    34435.367440
 > ## Inspecting Data
 >
 > After reading the data for the Americas,
-> use `help(americas.head)` and `help(americas.tail)`
+> use `help(data_americas.head)` and `help(data_americas.tail)`
 > to find out what `DataFrame.head` and `DataFrame.tail` do.
 >
 > 1.  What method call will display the first three rows of this data?
@@ -253,13 +255,13 @@ max      23424.766830    26997.936570    30687.754730    34435.367440
 >     (Hint: you may need to change your view of the data.)
 >
 > > ## Solution
-> > 1. We can check out the first five rows of `americas` by executing `americas.head()`
-> >    (allowing us to view the head of the DataFrame). We can specify the number of rows we wish
-> >    to see by specifying the parameter `n` in our call
-> >    to `americas.head()`. To view the first three rows, execute:
+> > 1. We can check out the first five rows of `data_americas` by executing `data_americas.head()`
+> >    which lets us view the beginning of the DataFrame. We can specify the number of rows we wish
+> >    to see by specifying the parameter `n` in our call to `data_americas.head()`.
+> >    To view the first three rows, execute:
 > >
 > >    ~~~
-> >    americas.head(n=3)
+> >    data_americas.head(n=3)
 > >    ~~~
 > >    {: .language-python}
 > >    ~~~
@@ -269,7 +271,7 @@ max      23424.766830    26997.936570    30687.754730    34435.367440
 > >    Bolivia    Americas     2677.326347     2127.686326     2180.972546
 > >    Brazil     Americas     2108.944355     2487.365989     3336.585802
 > >
-> >               gdpPercap_1967  gdpPercap_1972  gdpPercap_1977  gdpPercap_1982  \
+> >              gdpPercap_1967  gdpPercap_1972  gdpPercap_1977  gdpPercap_1982  \
 > >    country
 > >    Argentina     8052.953021     9443.038526    10079.026740     8997.897412
 > >    Bolivia       2586.886053     2980.331339     3548.097832     3156.510452
@@ -288,13 +290,13 @@ max      23424.766830    26997.936570    30687.754730    34435.367440
 > >    Brazil        9065.800825
 > >    ~~~
 > >    {: .output}
-> > 2. To check out the last three rows of `americas`, we would use the command,
+> > 2. To check out the last three rows of `data_americas`, we would use the command,
 > >    `americas.tail(n=3)`, analogous to `head()` used above. However, here we want to look at
 > >    the last three columns so we need to change our view and then use `tail()`. To do so, we
 > >     create a new DataFrame in which rows and columns are switched:
 > >
 > >    ~~~
-> >    americas_flipped = americas.T
+> >    americas_flipped = data_americas.T
 > >    ~~~
 > >    {: .language-python}
 > >
@@ -335,7 +337,7 @@ max      23424.766830    26997.936570    30687.754730    34435.367440
 > >    {: .language-python}    
 > >    __Note:__ we could have done the above in a single line of code by 'chaining' the commands:
 > >    ~~~
-> >    americas.T.tail(n=3).T
+> >    data_americas.T.tail(n=3).T
 > >    ~~~
 > >    {: .language-python}
 > {: .solution}
@@ -379,17 +381,19 @@ max      23424.766830    26997.936570    30687.754730    34435.367440
 > write one of your dataframes to a file called `processed.csv`.
 > You can use `help` to get information on how to use `to_csv`.
 > > ## Solution
-> > In order to write the DataFrame `americas` to a file called `processed.csv`, execute the following command:
+> > In order to write the DataFrame `data_americas` to a file called `processed.csv`, execute the following command:
 > > ~~~
-> > americas.to_csv('processed.csv')
+> > data_americas.to_csv('processed.csv')
 > > ~~~
-> >{: .language-python}
-> > For help on `to_csv`, you could execute, for example:
+> > {: .language-python}
+> > For help on `read_csv` or `to_csv`, you could execute, for example:
 > > ~~~
-> > help(americas.to_csv)
+> > help(data_americas.to_csv)
+> > help(pd.read_csv)
 > > ~~~
-> >{: .language-python}
-> > Note that `help(to_csv)` throws an error! This is a subtlety and is due to the fact that `to_csv` is NOT a function in 
-> > and of itself and the actual call is `americas.to_csv`. 
+> > {: .language-python}
+> > Note that `help(to_csv)` or `help(pd.to_csv)` throws an error! This is due to the fact that `to_csv` is not a global Pandas function, but
+> > a member function of DataFrames. This means you can only call it on an instance of a DataFrame
+> > e.g., `data_americas.to_csv` or `data_oceania.to_csv`
 > {: .solution}
 {: .challenge}


### PR DESCRIPTION
Updated lesson to use dataframe names following a similar standard convention (data_[region]_[indexColumn]) throughout and added bullets pointing out the advantages.

These changes should be consistent across all episodes to demonstrate preferred naming conventions.  Previously dataframes were overwritten and less clearly distinguishable (e.g. `data`).

refs #628