### PR TITLE
update zenodo json for lesson release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,23 +2,18 @@
   "contributors": [
     {
       "type": "Editor",
-      "name": "Nathan Thomas Moore",
-      "orcid": "0000-0001-8590-8349"
-    },
-    {
-      "type": "Editor",
       "name": "Allen Lee",
       "orcid": "0000-0002-6523-6079"
     },
     {
       "type": "Editor",
-      "name": "Sourav Singh",
-      "orcid": "0000-0002-9184-3091"
+      "name": "Olav Vahtras",
+      "orcid": "0000-0002-9123-8174"
     },
     {
       "type": "Editor",
-      "name": "Olav Vahtras",
-      "orcid": "0000-0002-9123-8174"
+      "name": "Sourav Singh",
+      "orcid": "0000-0002-9184-3091"
     }
   ],
   "creators": [
@@ -27,206 +22,197 @@
       "orcid": "0000-0002-6523-6079"
     },
     {
-      "name": "Florian Goth",
-      "orcid": "0000-0003-2707-4790"
+      "name": "Vini Salazar",
+      "orcid": "0000-0002-8362-3195"
     },
     {
       "name": "Olav Vahtras",
       "orcid": "0000-0002-9123-8174"
     },
     {
-      "name": "Raniere Silva"
+      "name": "Elizabeth Prout"
     },
     {
-      "name": "Steven Koenig"
+      "name": "Alexander James Ball"
+    },
+    {
+      "name": "Maxim Belkin"
+    },
+    {
+      "name": "Katrin Leinweber",
+      "orcid": "0000-0001-5135-5758"
+    },
+    {
+      "name": "Sarah LR Stevens",
+      "orcid": "0000-0002-7040-548X"
+    },
+    {
+      "name": "antoine"
+    },
+    {
+      "name": "Elizabeth Dobbins",
+      "orcid": "0000-0002-4014-977X"
+    },
+    {
+      "name": "Santiago Rubén Soler",
+      "orcid": "0000-0001-9202-5317"
+    },
+    {
+      "name": "mhagdorn"
+    },
+    {
+      "name": "Brandon Bentley"
+    },
+    {
+      "name": "David Perez-Suarez"
+    },
+    {
+      "name": "Maneesha Sane"
+    },
+    {
+      "name": "Martino Sorbaro Sindaci",
+      "orcid": "0000-0002-0182-7443"
+    },
+    {
+      "name": "Max Paulus"
+    },
+    {
+      "name": "Nathaniel Porter",
+      "orcid": "0000-0002-0479-6777"
+    },
+    {
+      "name": "Neil Francis"
+    },
+    {
+      "name": "Trevor Keller"
+    },
+    {
+      "name": "Elizabeth Alpert"
+    },
+    {
+      "name": "J Abraham Avelar-Rivas"
+    },
+    {
+      "name": "Alan Crosswell"
+    },
+    {
+      "name": "Alex Coleman"
+    },
+    {
+      "name": "Alexandre B. A. Villares",
+      "orcid": "0000-0001-7092-8654"
+    },
+    {
+      "name": "Annajiat Alim Rasel",
+      "orcid": "0000-0003-0198-3734"
+    },
+    {
+      "name": "Callum Macdonald Walley"
+    },
+    {
+      "name": "Cara Conradsen"
+    },
+    {
+      "name": "Chasz Griego",
+      "orcid": "0000-0002-2051-7491"
+    },
+    {
+      "name": "David Pugh",
+      "orcid": "0000-0001-7077-7331"
+    },
+    {
+      "name": "Eric Perlman"
+    },
+    {
+      "name": "Guy Davidson"
+    },
+    {
+      "name": "Harry Moss",
+      "orcid": "0000-0001-6497-3619"
+    },
+    {
+      "name": "Huajin Wang"
+    },
+    {
+      "name": "Jacob Deppen"
+    },
+    {
+      "name": "Jesko Wagner"
+    },
+    {
+      "name": "Jitao David Zhang"
+    },
+    {
+      "name": "Johannes Schmölder"
+    },
+    {
+      "name": "Kimberly Meechan",
+      "orcid": "0000-0003-4939-4170"
     },
     {
       "name": "Lex Nederbragt",
       "orcid": "0000-0001-5539-0999"
     },
     {
-      "name": "Sourav Singh",
-      "orcid": "0000-0002-9184-3091"
+      "name": "Mark Crowe",
+      "orcid": "0000-0002-9514-2487"
     },
     {
-      "name": "Thor Wikfeldt"
+      "name": "Matt Stone"
     },
     {
-      "name": "Carlos Henrique Brandt",
-      "orcid": "0000-0001-6679-3777"
+      "name": "Nicolás Guarín-Zapata",
+      "orcid": "0000-0002-9435-1914"
     },
     {
-      "name": "Shyam Dwaraknath"
+      "name": "Nik Khadijah Nik Aznan"
     },
     {
-      "name": "Jarno Rantaharju",
-      "orcid": "0000-0002-0072-7707"
+      "name": "Pablo Rodríguez-Sánchez"
     },
     {
-      "name": "Jacob Deppen"
+      "name": "Patrick Smyth"
     },
     {
-      "name": "Jeremy Zucker"
+      "name": "Phil Reed",
+      "orcid": "0000-0002-4479-715X"
     },
     {
-      "name": "Mike Henry"
+      "name": "Renato Alves",
+      "orcid": "0000-0002-7212-0234"
     },
     {
-      "name": "Pablo Hernandez-Cerdan"
+      "name": "Rodrigo L.C"
     },
     {
-      "name": "Kees den Heijer",
-      "orcid": "0000-0003-0314-2779"
+      "name": "Stefania Marcotti",
+      "orcid": "0000-0002-2877-0133"
     },
     {
-      "name": "Maxim Belkin"
+      "name": "Steve Göring"
     },
     {
-      "name": "Andreas Hilboll",
-      "orcid": "0000-0002-1038-6248"
+      "name": "Tim Machado"
     },
     {
-      "name": "Taylor Smith"
+      "name": "ppxasjsm",
+      "orcid": "0000-0001-7512-5252"
     },
     {
-      "name": "Adam Steer"
+      "name": "dev-vw",
+      "orcid": "0000-0001-7117-0160"
     },
     {
-      "name": "David Matten",
-      "orcid": "0000-0003-1085-4344"
+      "name": "Woodrow Wilson"
     },
     {
-      "name": "Erin Alison Becker",
-      "orcid": "0000-0002-6832-0233"
+      "name": "dilx3"
     },
     {
-      "name": "Francisco J. Martínez"
+      "name": "Maryam Montazerolghaem"
     },
     {
-      "name": "Paul Anzel"
-    },
-    {
-      "name": "Robert Woodward"
-    },
-    {
-      "name": "Ashley Champagne"
-    },
-    {
-      "name": "Benjamin"
-    },
-    {
-      "name": "Benjamin Roberts"
-    },
-    {
-      "name": "CanWood"
-    },
-    {
-      "name": "Cephalopd"
-    },
-    {
-      "name": "Cian Wilson"
-    },
-    {
-      "name": "Daniel W Kerchner",
-      "orcid": "0000-0002-5921-2193"
-    },
-    {
-      "name": "Dan Mønster"
-    },
-    {
-      "name": "Daria Orlowska"
-    },
-    {
-      "name": "Dave Lampert",
-      "orcid": "0000-0001-7357-1873"
-    },
-    {
-      "name": "Greg Wilson"
-    },
-    {
-      "name": "ian"
-    },
-    {
-      "name": "Jonah Duckles",
-      "orcid": "0000-0002-8985-3119"
-    },
-    {
-      "name": "Keith Gilbertson"
-    },
-    {
-      "name": "Kyle E Niemeyer",
-      "orcid": "0000-0003-4425-7097"
-    },
-    {
-      "name": "Logan Cox",
-      "orcid": "0000-0003-1566-542X"
-    },
-    {
-      "name": "Louis Vernon"
-    },
-    {
-      "name": "Lucy Dorothy Whalley",
-      "orcid": "0000-0002-2992-9871"
-    },
-    {
-      "name": "Madeleine Bonsma-Fisher",
-      "orcid": "0000-0002-5813-4664"
-    },
-    {
-      "name": "Mark Phillips"
-    },
-    {
-      "name": "Mark Slater"
-    },
-    {
-      "name": "Michael Beyeler"
-    },
-    {
-      "name": "mzc9"
-    },
-    {
-      "name": "Narayanan Raghupathy"
-    },
-    {
-      "name": "Nigel Bosch"
-    },
-    {
-      "name": "Carlos M Ortiz Marrero",
-      "orcid": "0000-0001-8302-1322"
-    },
-    {
-      "name": "Phil Tooley"
-    },
-    {
-      "name": "Ryan Avery"
-    },
-    {
-      "name": "Ryan Gregory James",
-      "orcid": "0000-0003-2149-9085"
-    },
-    {
-      "name": "Sarah M Brown",
-      "orcid": "0000-0001-5728-0822"
-    },
-    {
-      "name": "SBolo"
-    },
-    {
-      "name": "Stéphane Guillou",
-      "orcid": "0000-0001-8992-0951"
-    },
-    {
-      "name": "Timothy Warren"
-    },
-    {
-      "name": "Tyler Martin"
-    },
-    {
-      "name": "Vasu Venkateshwaran",
-      "orcid": "0000-0002-0690-0056"
-    },
-    {
-      "name": "Vikas Pejaver"
+      "name": "nacl"
     }
   ],
   "license": {


### PR DESCRIPTION
updating the `.zenodo.json` with metadata about contributors since last release, in preparation for the infrastructure transition.