### PR TITLE
Replace the basic summation example with a simple simulation of coin-…

### DIFF
--- a/episodes/12-for-loops.md
+++ b/episodes/12-for-loops.md
@@ -147,25 +147,27 @@ a range is not a list: range(0, 3)
 
 - A common pattern in programs is to:
   1. Initialize an *accumulator* variable to zero, the empty string, or the empty list.
-  2. Update the variable with values from a collection.
+  2. Update the variable incrementally, this might use the values of the loop variable, but doesn't have to.
 
 ```python
-# Sum the first 10 integers.
-total = 0
-for number in range(10):
-   total = total + (number + 1)
-print(total)
+# Simulating 100 coin flips.
+import random
+
+total_flips = 100
+total_heads = 0
+for flip in range(total_flips):
+    if random.random() < 0.5:
+      total_heads += 1
+
+print(f'Of {total_flips} coin flips, {total_heads} were heads.')
 ```
 
 ```output
-55
+Of 100 coin flips, 48 were heads.
 ```
 
-- Read `total = total + (number + 1)` as:
-  - Add 1 to the current value of the loop variable `number`.
-  - Add that to the current value of the accumulator variable `total`.
-  - Assign that to `total`, replacing the current value.
-- We have to add `number + 1` because `range` produces 0..9, not 1..10.
+- Read `total_heads += 1` as:
+  - Add 1 to the the accumulator variable `total_heads`, replacing the current value.
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 


### PR DESCRIPTION
 Issue #636:Examples / exercises encourage anti-patterns in 12-for-loops.md 

Replace the example somewhat heavy-handed summation over a loop variable with a simulation of coin tosses:

1) It's *entirely* valid for an accumulator to *not* depend on the loop variable, c.f. Monte-Carlo integration.
2) We shouldn't solve the problem of `range` starting from zero with spurious additions in a loop, just use `range` properly. 3) A trivial summation over the loop variable should be done with the built-in `sum` function.
4) The later exercise with a cumulative sum is a far better example.

Imports have been introduced previously, so it's probably okay to use random.random()
Other examples in the episode use if statements, but this is just more justification to switch the conditionals and loops episodes; conditionals are more fundamental than loops, if you don't have conditional branches, you're not Turing-Complete, and you don't really have a language.

Delete the string revering exercise.
1) Strings, and other sequences are more idiomatically reversed with slice operators.
2) The other exercises with string accumulators are much better.

 On branch loops_grg
	modified:   episodes/12-for-loops.md

