### PR TITLE
Clarify kernel name.

### DIFF
--- a/episodes/01-run-quit.md
+++ b/episodes/01-run-quit.md
@@ -156,7 +156,7 @@ menus are included by default.
 The JupyterLab [docs](https://jupyterlab.readthedocs.io/en/stable/user/documents_kernels.html)
 define kernels as "separate processes started by the server that runs your code in different programming languages and environments."
 When we open a Jupyter Notebook, that starts a kernel - a process - that is going to run the code.
-In this lesson, we'll be using the Jupyter ipython kernel which lets us run Python 3 code interactively.
+In this lesson, we'll be using the IPython kernel (ipykernel), which lets us run Python 3 code in Jupyter.
 
 Using other Jupyter [kernels for other programming languages](https://github.com/jupyter/jupyter/wiki/Jupyter-kernels) would let us
 write and execute code in other programming languages in the same JupyterLab interface, like R, Java, Julia, Ruby, JavaScript, Fortran,


### PR DESCRIPTION
Dear maintainers,

This is minor, but I found myself hesitating for a second while teaching this [yesterday](https://github.com/mkcor/python-prog/blob/33bbbf2b3f3c3999d5e5006dfb59772a398cf50f/_episodes/00-run-quit.md).

I suggest this slight change:

* because the icon on the JupyterLab landing page reads "Python 3 (ipykernel);"
* based on "The IPython kernel is the Python execution backend for Jupyter" from the [official docs](https://ipython.readthedocs.io/en/stable/install/kernel_install.html).

/cc @JohanMabille