### PR TITLE
628 explicit df names

### DIFF
--- a/episodes/08-data-frames.md
+++ b/episodes/08-data-frames.md
@@ -333,7 +333,7 @@ and the Gapminder GDP data for Europe has been loaded:
 ```python
 import pandas as pd
 
-europe = pd.read_csv('data/gapminder_gdp_europe.csv', index_col='country')
+data_europe = pd.read_csv('data/gapminder_gdp_europe.csv', index_col='country')
 ```
 
 Write an expression to find the Per Capita GDP of Serbia in 2007.
@@ -345,7 +345,7 @@ Write an expression to find the Per Capita GDP of Serbia in 2007.
 The selection can be done by using the labels for both the row ("Serbia") and the column ("gdpPercap\_2007"):
 
 ```python
-print(europe.loc['Serbia', 'gdpPercap_2007'])
+print(data_europe.loc['Serbia', 'gdpPercap_2007'])
 ```
 
 The output is
@@ -367,8 +367,8 @@ The output is
   what rule governs what is included (or not) in numerical slices and named slices in Pandas?
 
 ```python
-print(europe.iloc[0:2, 0:2])
-print(europe.loc['Albania':'Belgium', 'gdpPercap_1952':'gdpPercap_1962'])
+print(data_europe.iloc[0:2, 0:2])
+print(data_europe.loc['Albania':'Belgium', 'gdpPercap_1952':'gdpPercap_1962'])
 ```
 
 :::::::::::::::  solution

--- a/episodes/08-data-frames.md
+++ b/episodes/08-data-frames.md
@@ -333,7 +333,7 @@ and the Gapminder GDP data for Europe has been loaded:
 ```python
 import pandas as pd
 
-df = pd.read_csv('data/gapminder_gdp_europe.csv', index_col='country')
+europe = pd.read_csv('data/gapminder_gdp_europe.csv', index_col='country')
 ```
 
 Write an expression to find the Per Capita GDP of Serbia in 2007.
@@ -345,7 +345,7 @@ Write an expression to find the Per Capita GDP of Serbia in 2007.
 The selection can be done by using the labels for both the row ("Serbia") and the column ("gdpPercap\_2007"):
 
 ```python
-print(df.loc['Serbia', 'gdpPercap_2007'])
+print(europe.loc['Serbia', 'gdpPercap_2007'])
 ```
 
 The output is
@@ -367,8 +367,8 @@ The output is
   what rule governs what is included (or not) in numerical slices and named slices in Pandas?
 
 ```python
-print(df.iloc[0:2, 0:2])
-print(df.loc['Albania':'Belgium', 'gdpPercap_1952':'gdpPercap_1962'])
+print(europe.iloc[0:2, 0:2])
+print(europe.loc['Albania':'Belgium', 'gdpPercap_1952':'gdpPercap_1962'])
 ```
 
 :::::::::::::::  solution

--- a/episodes/16-writing-functions.md
+++ b/episodes/16-writing-functions.md
@@ -458,8 +458,8 @@ Assume that the following code has been executed:
 ```python
 import pandas as pd
 
-asia = pd.read_csv('data/gapminder_gdp_asia.csv', index_col=0)
-japan = asia.loc['Japan']
+data_asia = pd.read_csv('data/gapminder_gdp_asia.csv', index_col=0)
+japan = data_asia.loc['Japan']
 ```
 
 1. Complete the statements below to obtain the average GDP for Japan
@@ -475,7 +475,7 @@ japan = asia.loc['Japan']
   
   ```python
   def avg_gdp_in_decade(country, continent, year):
-      countries = pd.read_csv('data/gapminder_gdp_'+___+'.csv',delimiter=',',index_col=0)
+      data_countries = pd.read_csv('data/gapminder_gdp_'+___+'.csv',delimiter=',',index_col=0)
       ____
       ____
       ____
@@ -504,8 +504,8 @@ japan = asia.loc['Japan']
   
   ```python
   def avg_gdp_in_decade(country, continent, year):
-      countries = pd.read_csv('data/gapminder_gdp_' + continent + '.csv', index_col=0)
-      c = countries.loc[country]
+      data_countries = pd.read_csv('data/gapminder_gdp_' + continent + '.csv', index_col=0)
+      c = data_countries.loc[country]
       gdp_decade = 'gdpPercap_' + str(year // 10)
       avg = (c.loc[gdp_decade + '2'] + c.loc[gdp_decade + '7'])/2
       return avg
@@ -515,8 +515,8 @@ japan = asia.loc['Japan']
   
   ```python
   def avg_gdp_in_decade(country, continent, year):
-      countries = pd.read_csv('data/gapminder_gdp_' + continent + '.csv', index_col=0)
-      c = countries.loc[country]
+      data_countries = pd.read_csv('data/gapminder_gdp_' + continent + '.csv', index_col=0)
+      c = data_countries.loc[country]
       gdp_decade = 'gdpPercap_' + str(year // 10)
       total = 0.0
       num_years = 0

--- a/episodes/16-writing-functions.md
+++ b/episodes/16-writing-functions.md
@@ -458,8 +458,8 @@ Assume that the following code has been executed:
 ```python
 import pandas as pd
 
-df = pd.read_csv('data/gapminder_gdp_asia.csv', index_col=0)
-japan = df.loc['Japan']
+asia = pd.read_csv('data/gapminder_gdp_asia.csv', index_col=0)
+japan = asia.loc['Japan']
 ```
 
 1. Complete the statements below to obtain the average GDP for Japan
@@ -475,7 +475,7 @@ japan = df.loc['Japan']
   
   ```python
   def avg_gdp_in_decade(country, continent, year):
-      df = pd.read_csv('data/gapminder_gdp_'+___+'.csv',delimiter=',',index_col=0)
+      countries = pd.read_csv('data/gapminder_gdp_'+___+'.csv',delimiter=',',index_col=0)
       ____
       ____
       ____
@@ -504,8 +504,8 @@ japan = df.loc['Japan']
   
   ```python
   def avg_gdp_in_decade(country, continent, year):
-      df = pd.read_csv('data/gapminder_gdp_' + continent + '.csv', index_col=0)
-      c = df.loc[country]
+      countries = pd.read_csv('data/gapminder_gdp_' + continent + '.csv', index_col=0)
+      c = countries.loc[country]
       gdp_decade = 'gdpPercap_' + str(year // 10)
       avg = (c.loc[gdp_decade + '2'] + c.loc[gdp_decade + '7'])/2
       return avg
@@ -515,8 +515,8 @@ japan = df.loc['Japan']
   
   ```python
   def avg_gdp_in_decade(country, continent, year):
-      df = pd.read_csv('data/gapminder_gdp_' + continent + '.csv', index_col=0)
-      c = df.loc[country]
+      countries = pd.read_csv('data/gapminder_gdp_' + continent + '.csv', index_col=0)
+      c = countries.loc[country]
       gdp_decade = 'gdpPercap_' + str(year // 10)
       total = 0.0
       num_years = 0


### PR DESCRIPTION
Fix #628 

Episode 8:
- Renamed `df` to `europe`

Episode 16:
- Renamed `df` to `asia` for the first specific case
- Renamed `df` to `countries` in the function writing exercise, since the generic `continent` is already used