### PR TITLE
link to dedicated installation instructions page in workshop template

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -12,7 +12,7 @@ server in the root directory (see [Starting JupyterLab](episodes/01-run-quit.md#
 
 ## Installing Python Using Anaconda
 
-Please refer to the [Python section of the workshop website for installation instructions.](https://carpentries.github.io/workshop-template/#python)
+Please refer to the [Python section of the workshop website for installation instructions.](https://carpentries.github.io/workshop-template/install_instructions/#python)
 
 
 


### PR DESCRIPTION
To reduce confusion for learners visiting the installation instructions, this links to a dedicated page of installation instructions in the template workshop website. This is instead of the template landing page, which contains a lot of FIXMEs that can be alarming and give someone the impression that the link has taken them to the wrong place.