### PR TITLE
fix: remove leftover jekyll `auto_ids` directive

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -201,7 +201,6 @@ add_numbers(1, 4)
 
 ## Glossary
 
-{:auto\_ids}
 Arguments
 :     Values passed to functions.
 


### PR DESCRIPTION
closes #658