### PR TITLE
Update 14-looping-data-sets.md

### DIFF
--- a/episodes/14-looping-data-sets.md
+++ b/episodes/14-looping-data-sets.md
@@ -201,7 +201,7 @@ for filename in glob.glob('data/gapminder_gdp*.csv'):
     # retrieve the last string in the list that split returns (`<region>.csv`), 
     # and then remove the `.csv` extension from that string.
     region = filename.split('_')[-1][:-4] 
-    dataframe.mean().plot(ax=ax, label=region)
+    dataframe.mean(numeric_only=True).plot(ax=ax, label=region)
 plt.legend()
 plt.show()
 ```


### PR DESCRIPTION
This avoids the FutureWarning: The default value of numeric_only in DataFrame.mean is deprecated. In a future version, it will default to False. In addition, specifying 'numeric_only=None' is deprecated. Select only valid columns or specify the value of numeric_only to silence this warning.

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
