### PR TITLE
Update 14-looping-data-sets.md

### DIFF
--- a/episodes/14-looping-data-sets.md
+++ b/episodes/14-looping-data-sets.md
@@ -222,7 +222,9 @@ directories. In the example below, we create a `Path` object and inspect its att
 from pathlib import Path
 
 p = Path("data/gapminder_gdp_africa.csv")
-print(p.parent), print(p.stem), print(p.suffix)
+print(p.parent)
+print(p.stem)
+print(p.suffix)
 ```
 
 ```output


### PR DESCRIPTION
If you run the original command,
print(p.parent), print(p.stem), print(p.suffix)

The output is,
data
gapminder_gdp_africa
.csv

(None, None, None)

The last line is confusing, "(None, None, None)"

You're essentially doing three separate print calls and then creating a tuple with their return values. The print function in Python doesn't return any meaningful value (it returns None), so when you group them together with commas, you're creating a tuple of their return values, which is (None, None, None).

To get a clean output like you see in the lessons, you have to write the print statement on three separate lines.

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
