### PR TITLE
convert divs into table

### DIFF
--- a/episodes/01-run-quit.md
+++ b/episodes/01-run-quit.md
@@ -339,161 +339,64 @@ You need to be in Command mode (Press <kbd>Esc</kbd> if your cell is blue).  Typ
 
 ### Markdown does most of what HTML does.
 
-<div class="row">
+Table: Showing some markdown syntax and its rendered output.
 
-  <div class="col-md-6" markdown="1">
++---------------------------------------+------------------------------------------------+
+| Markdown code                         | Rendered output                                |
++=======================================+================================================+
++---------------------------------------+------------------------------------------------+
+| ```                                   | <p></p>                                        |
+| *   Use asterisks                     | -   Use asterisks                              |
+| *   to create                         | -   to create                                  |
+| *   bullet lists.                     | -   bullet lists.                              |
+| ```                                   |                                                |
++---------------------------------------+------------------------------------------------+
++---------------------------------------+------------------------------------------------+
+| ```                                   | <p></p>                                        |
+| 1.   Use numbers                      | 1.   Use numbers                               |
+| 1.   to create                        | 2.   to create                                 |
+| 1.   bullet lists.                    | 3.   numbered lists.                           |
+| ```                                   |                                                |
++---------------------------------------+------------------------------------------------+
++---------------------------------------+------------------------------------------------+
+| ```                                   | <p></p>                                        |
+| *  You can use indents                | - You can use indents                          |
+|   *  To create sublists               |   - To create sublists                         |
+|   *  of the same type                 |   - of the same type                           |
+| *  Or sublists                        | - Or sublists                                  |
+|   1. Of different                     |   1. Of different                              |
+|   1. types                            |   2. types                                     |
+| ```                                   |                                                |
++---------------------------------------+------------------------------------------------+
++---------------------------------------+------------------------------------------------+
+| ```                                   | <p></p>                                        |
+| # A Level-1 Heading                   | ## A Level-1 Heading                           |
+| ```                                   |                                                |
++---------------------------------------+------------------------------------------------+
++---------------------------------------+------------------------------------------------+
+| ```                                   | <p></p>                                        |
+| ## A Level-2 Heading (etc.)           | ### A Level-2 Heading (etc.)                   |
+| ```                                   |                                                |
++---------------------------------------+------------------------------------------------+
++---------------------------------------+------------------------------------------------+
+| ```                                   | <p></p>                                        |
+| Line breaks                           | Line breaks                                    |
+| don't matter.                         | don't matter.                                  |
+|                                       |                                                |
+| But blank lines                       | But blank lines                                |
+| create new paragraphs.                | create new paragraphs.                         |
+| ```                                   |                                                |
++---------------------------------------+------------------------------------------------+
++---------------------------------------+------------------------------------------------+
+| ```                                   | <p></p>                                        |
+| [Links](http://software-carpentry.org)| [Links](https://software-carpentry.org)        |
+| are created with `[...](...)`.        | are created with `[...](...)`.                 |
+| Or use [named links][data-carp].      | Or use [named links][data_carpentry].          |
+|                                       |                                                |
+| [data-carp]: http://datacarpentry.org |                                                |
+| ```                                   |                                                |
++---------------------------------------+------------------------------------------------+
 
-```
-*   Use asterisks
-*   to create
-*   bullet lists.
-```
-
-  </div>
-
-  <div class="col-md-6" markdown="1">
-
-- Use asterisks
-- to create
-- bullet lists.
-
-  </div>
-
-</div>
-
-<div class="row">
-
-  <div class="col-md-6" markdown="1">
-
-```
-1.  Use numbers
-1.  to create
-1.  numbered lists.
-```
-
-  </div>
-
-  <div class="col-md-6" markdown="1">
-
-1. Use numbers
-2. to create
-3. numbered lists.
-
-  </div>
-
-</div>
-
-<div class="row">
-
-  <div class="col-md-6" markdown="1">
-
-```
-*  You can use indents
-	*  To create sublists 
-	*  of the same type
-*  Or sublists
-	1. Of different
-	1. types
-```
-
-  </div>
-
-  <div class="col-md-6" markdown="1">
-
-- You can use indents
-  - To create sublists
-  - of the same type
-- Or sublists
-  1. Of different
-  2. types
-
-  </div>
-
-</div>
-
-<div class="row">
-
-  <div class="col-md-6" markdown="1">
-
-```
-# A Level-1 Heading
-```
-
-  </div>
-
-  <div class="col-md-6" markdown="1">
-
-## A Level-1 Heading
-
-  </div>
-
-</div>
-
-<div class="row">
-
-  <div class="col-md-6" markdown="1">
-
-```
-## A Level-2 Heading (etc.)
-```
-
-  </div>
-
-  <div class="col-md-6" markdown="1">
-
-## A Level-2 Heading (etc.)
-
-  </div>
-
-</div>
-
-<div class="row">
-
-  <div class="col-md-6" markdown="1">
-
-```
-Line breaks
-don't matter.
-
-But blank lines
-create new paragraphs.
-```
-
-  </div>
-
-  <div class="col-md-6" markdown="1">
-
-Line breaks
-don't matter.
-
-But blank lines
-create new paragraphs.
-
-  </div>
-
-</div>
-
-<div class="row">
-
-  <div class="col-md-6" markdown="1">
-
-```
-[Create links](http://software-carpentry.org) with `[...](...)`.
-Or use [named links][data_carpentry].
-
-[data_carpentry]: http://datacarpentry.org
-```
-
-  </div>
-
-  <div class="col-md-6" markdown="1">
-
-[Create links](https://software-carpentry.org) with `[...](...)`.
-Or use [named links][data_carpentry].
-
-  </div>
-
-</div>
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 


### PR DESCRIPTION
cherry picking work from @martinosorb in #677 

Context from that PR:


> This is apparently needed for the lesson to be workable with Crowdin for internationalisation purposes (see [this thread on Slack](https://carpentries.slack.com/archives/CL357S0CD/p1708392714885819?thread_ts=1706754620.155089&cid=CL357S0CD)).
> 
> Please note that I can't, at the moment, check whether the version in this PR will actually work in Crowdin -- but the problem there is supposed to be about the use of \<div\>.
> 
> What the PR does is to change the [section on Markdown](http://swcarpentry.github.io/python-novice-gapminder/01-run-quit.html#the-notebook-has-command-and-edit-modes.) of the first episode to look like this:
> ![image](https://github.com/swcarpentry/python-novice-gapminder/assets/11293950/8ed7c87a-36db-4efa-9b67-f84b64b69305)
> 
> Also fixes a typo by which the level-2 header looked the same as the level-1 header.