### PR TITLE
Three "gdp" -> "GDP" on Plotting page

### DIFF
--- a/episodes/09-plotting.md
+++ b/episodes/09-plotting.md
@@ -248,7 +248,7 @@ data_asia.describe().T.plot(kind='scatter', x='min', y='max')
 
 ![](fig/9_correlations_solution1.svg){alt='Correlations Solution 1'}
 
-No particular correlations can be seen between the minimum and maximum gdp values
+No particular correlations can be seen between the minimum and maximum GDP values
 year on year. It seems the fortunes of asian countries do not rise and fall together.
 
 
@@ -273,7 +273,7 @@ print(data_asia.idxmin())
 Seems the variability in this value is due to a sharp drop after 1972.
 Some geopolitics at play perhaps? Given the dominance of oil producing countries,
 maybe the Brent crude index would make an interesting comparison?
-Whilst Myanmar consistently has the lowest gdp, the highest gdb nation has varied
+Whilst Myanmar consistently has the lowest GDP, the highest GDP nation has varied
 more notably.
 
 


### PR DESCRIPTION
Corrects three occurrences of lower case "gdp" on the page on [plotting](https://swcarpentry.github.io/python-novice-gapminder/instructor/09-plotting.html), including one typo ("gdb"). 

The rest of the page consistenly uses capital GDP.