### PR TITLE
Add first draft of learner-profiles

### DIFF
--- a/profiles/learner-profiles.md
+++ b/profiles/learner-profiles.md
@@ -8,6 +8,8 @@ Carla is a social scientist with a PhD in Sociology and 2 years of research expe
 
 This course will teach Carla the Python fundamentals needed to analyze cross-country demographic data for her paper on education outcomes. She's particularly interested in the data importing, visualization, and statistical analysis episodes. After completing the workshop, Carla will be able to independently import CSV files, perform basic data cleaning, create simple visualizations of demographic trends, and produce summary statistics from tabular data without relying on colleagues for code support.
 
+This workshop serves as a first step in Carla's Python journey, providing her with a coherent mental model of programming and data visualization that will form the foundation of her future learning. She will be equipped to ask well informed questions about programming in the future, recognize what's possible with Python, and independently explore resources to expand her skills.
+
 ## Jim JIT
 
 Jim teaches biology and environmental science to high school students with 12 years of teaching experience. While comfortable with educational technology, he has no programming experience. He wants to incorporate real-world data analysis into his curriculum to engage students with current global challenges and teach them valuable skills, but is concerned about simplifying complex concepts for teenage students and designing activities that can fit within 45-minute class periods.

--- a/profiles/learner-profiles.md
+++ b/profiles/learner-profiles.md
@@ -4,9 +4,9 @@ title: Learner Profiles
 
 ## Carla Correlation
 
-Maria is a social scientist with a PhD in Sociology and 2 years of research experience. She primarily uses SPSS for data analysis and has extensive domain knowledge in her field. Her department is increasingly adopting Python for research, but she has never written code beyond SPSS syntax files.
+Carla is a social scientist with a PhD in Sociology and 2 years of research experience. She primarily uses SPSS for data analysis and has extensive domain knowledge in her field. Her department is increasingly adopting Python for research, but she has never written code beyond SPSS syntax files.
 
-This course will teach Maria the Python fundamentals needed to analyze cross-country demographic data for her paper on education outcomes. She's particularly interested in the data importing, visualization, and statistical analysis episodes. After completing the workshop, Maria will be able to independently import CSV files, perform basic data cleaning, create simple visualizations of demographic trends, and produce summary statistics from tabular data without relying on colleagues for code support.
+This course will teach Carla the Python fundamentals needed to analyze cross-country demographic data for her paper on education outcomes. She's particularly interested in the data importing, visualization, and statistical analysis episodes. After completing the workshop, Carla will be able to independently import CSV files, perform basic data cleaning, create simple visualizations of demographic trends, and produce summary statistics from tabular data without relying on colleagues for code support.
 
 ## Jim JIT
 

--- a/profiles/learner-profiles.md
+++ b/profiles/learner-profiles.md
@@ -1,5 +1,21 @@
 ---
-title: FIXME
+title: Learner Profiles
 ---
 
-This is a placeholder file. Please add content here. 
+## Carla Correlation
+
+Maria is a social scientist with a PhD in Sociology and 2 years of research experience. She primarily uses SPSS for data analysis and has extensive domain knowledge in her field. Her department is increasingly adopting Python for research, but she has never written code beyond SPSS syntax files.
+
+This course will teach Maria the Python fundamentals needed to analyze cross-country demographic data for her paper on education outcomes. She's particularly interested in the data importing, visualization, and statistical analysis episodes. After completing the workshop, Maria will be able to independently import CSV files, perform basic data cleaning, create simple visualizations of demographic trends, and produce summary statistics from tabular data without relying on colleagues for code support.
+
+## Jim JIT
+
+Jim teaches biology and environmental science to high school students with 12 years of teaching experience. While comfortable with educational technology, he has no programming experience. He wants to incorporate real-world data analysis into his curriculum to engage students with current global challenges and teach them valuable skills, but is concerned about simplifying complex concepts for teenage students and designing activities that can fit within 45-minute class periods.
+
+This course will provide Jim with the foundational Python knowledge needed to create data science activities for his classroom. He's most interested in the basic programming concepts and data visualization aspects that he can adapt for student use. After the workshop, Jim will be able to create simple, guided activities using the Gapminder dataset that connect scientific concepts to real-world data, demonstrate basic data visualization techniques to his students, and confidently answer questions about the code. He'll develop lesson materials that help prepare his students for college-level coursework while teaching both scientific concepts and analytical skills.
+
+## Peter Pandas
+
+Peter is a medical student conducting research during a gap year before residency. With an MD degree completed and some undergraduate coursework in statistics, they need to analyze global health data for a project on childhood vaccination rates. Despite being tech-savvy with other digital tools, Peter has never programmed before and has very limited time available between clinical responsibilities. They struggle with abstract concepts and prefer learning through concrete examples directly applicable to their work.
+
+This course will teach Peter the essential Python skills needed to analyze datasets for their research projects. They're particularly interested in the data filtering and visualization episodes that will allow them to extract meaningful patterns from data. After completing the workshop, Peter will be able to import their research data, filter it based on specific criteria like geographic region or time period and create visualizations illustrating relationships. For repeated steps, they will be able to write functions to not have to repeat themselves.


### PR DESCRIPTION
Closes #664.


Based on issue #664, I'm adding some learner profiles for the course in place of the current (empty) placeholder.

This is my first time writing these sort of profiles, so I'd be happy for suggestions on improvements. I took these as inspirations:

- https://carpentries-incubator.github.io/python-packaging-publishing/learner-profiles/index.html
- https://github.com/carpentries-incubator/hpc-intro/blob/gh-pages/_extras/learner-profiles.md


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
