### PR TITLE
Mention pass by reference in episode 3

### DIFF
--- a/episodes/03-types-conversion.md
+++ b/episodes/03-types-conversion.md
@@ -175,17 +175,11 @@ three squared is 9.0
 
 ## Assignment changes the value of a variable, it does not create links between variables.
 
-- In the spreadsheet context,
-  - If we use a formula to connect one cell to another,
-    and update the latter,
-    the former updates automatically.
-  - In contrast, if we copy one cell and paste its contents into another cell,
-    the second cell will not update if the first cell changes.
-    To update the second cell, we would need to copy and paste again.
-- Assignment (the `=` operator) in python works like copy and paste in spreadsheets
-    not like a spreadsheet formula connecting the two cells.
-    In other words, after a variable is used to assign a value to another variable,
-    reassigning the first variable does not change the second variable.
+When there is a variable on the right side of `=`,
+it uses the current value of that variable
+to set the value of the variable on the left side.
+After that value is set, adjusting one variable
+doesn't impact the other.
 
 To demonstrate this:
 
@@ -200,7 +194,7 @@ print('a is', a, 'and b is', b)
 a is 2 and b is 1
 ```
 
-When `b = a` is run, `a`'s value (`1`) is assigned to `b`, but no ongoing link is created between `a` and `b`.
+When `b = a` is run, `a`'s value (`1`) is "assigned" to `b`, but no ongoing link is created between `a` and `b`.
 
 Here is a slightly more complicated example involving computation on the second value:
 
@@ -220,7 +214,7 @@ variable_one is 2 and variable_two is 5
 - Afterwards, `variable_two` is set to this new value and *is not dependent on `variable_one`* so its value
   does not automatically change when `variable_one` changes.
 
-Some data types that we haven't encountered yet (e.g. _lists_, _dictionaries_, and _objects_) have "links" inside them so they behave somewhat differently when you assign values to their *contents*. An example of this is shown in [Episode 12: Lists](../11-lists.md#copying-or-not). Assigning a list value to a new variable is like copying and pasting a formula from one cell to another. When you update an item in that list with the new value, you're updating that item in the original list as well. 
+Some data types that we haven't encountered yet (e.g. _lists_ and _dictionaries_) have "links" inside them so they behave somewhat differently when you assign values to their *contents*. An example of this is shown in [Episode 12: Lists](../11-lists.md#copying-or-not).
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

Closes #370

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

As requested in #370 , this change warns users about of pass-by-reference when they first learn about the concept of assignment.

In order avoid introducing and fully explaining the concepts of objects, pass-by-reference, and mutable/immutable (as @alee does beautifully in [this comment](https://github.com/swcarpentry/python-novice-gapminder/pull/499#pullrequestreview-512370133)), I use the term "links inside [the object]" to describe mutable objects with mutable references. Hopefully this describes the behavior without saying anything technically incorrect or getting too in-the-weeds for Episode 3. Maybe some of this more comprehensive explanation could be added to Episode 11, since the concept is introduced there but not thoroughly explained.

_If any relevant discussions have taken place elsewhere, please provide links to these._

I used #499 as a basis and kept the example and structure, but reworded completely.

<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
