### PR TITLE
Fix the typo in Markdown Code/Rendered Output table

### DIFF
--- a/episodes/01-run-quit.md
+++ b/episodes/01-run-quit.md
@@ -355,7 +355,7 @@ Table: Showing some markdown syntax and its rendered output.
 | ```                                   | <p></p>                                        |
 | 1.   Use numbers                      | 1.   Use numbers                               |
 | 1.   to create                        | 2.   to create                                 |
-| 1.   bullet lists.                    | 3.   numbered lists.                           |
+| 1.   numbered lists.                  | 3.   numbered lists.                           |
 | ```                                   |                                                |
 +---------------------------------------+------------------------------------------------+
 +---------------------------------------+------------------------------------------------+


### PR DESCRIPTION
During translation saw this inconsistency. Should there be "numbered" instead of "bullet"?