### PR TITLE
Fix example output in "writing functions" episode

### DIFF
--- a/episodes/16-writing-functions.md
+++ b/episodes/16-writing-functions.md
@@ -58,6 +58,8 @@ print_greeting()
 
 ```output
 Hello!
+The weather is nice today.
+Right?
 ```
 
 ## Arguments in a function call are matched to its defined parameters.


### PR DESCRIPTION
This is a follow-up to #607, which added two lines to the `print_greeting()` function, but forgot to update the output to match.