### PR TITLE
FIX: Lowercase "p" in pandas across all episodes

### DIFF
--- a/episodes/07-reading-tabular.md
+++ b/episodes/07-reading-tabular.md
@@ -6,9 +6,9 @@ exercises: 10
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- Import the Pandas library.
-- Use Pandas to load a simple CSV data set.
-- Get some basic information about a Pandas DataFrame.
+- Import the pandas library.
+- Use pandas to load a simple CSV data set.
+- Get some basic information about a pandas DataFrame.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -18,13 +18,13 @@ exercises: 10
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-## Use the Pandas library to do statistics on tabular data.
+## Use the pandas library to do statistics on tabular data.
 
-- [Pandas](https://pandas.pydata.org/) is a widely-used Python library for statistics, particularly on tabular data.
+- [pandas](https://pandas.pydata.org/) is a widely-used Python library for statistics, particularly on tabular data.
 - Borrows many features from R's dataframes.
   - A 2-dimensional table whose columns have names
     and potentially have different data types.
-- Load Pandas with `import pandas as pd`. The alias `pd` is commonly used to refer to the Pandas library in code.
+- Load pandas with `import pandas as pd`. The alias `pd` is commonly used to refer to the pandas library in code.
 - Read a Comma Separated Values (CSV) data file with `pd.read_csv`.
   - Argument is the name of the file to be read.
   - Returns a dataframe that you can assign to a variable
@@ -55,7 +55,7 @@ print(data_oceania)
 ```
 
 - The columns in a dataframe are the observed variables, and the rows are the observations.
-- Pandas uses backslash `\` to show wrapped lines when output is too wide to fit the screen.
+- pandas uses backslash `\` to show wrapped lines when output is too wide to fit the screen.
 - Using descriptive dataframe names helps us distinguish between multiple dataframes so we won't accidentally overwrite a dataframe or read from the wrong one.
 
 :::::::::::::::::::::::::::::::::::::::::  callout
@@ -396,7 +396,7 @@ data_microbes = pd.read_csv('../field_data/microbes.csv')
 ## Writing Data
 
 As well as the `read_csv` function for reading data from a file,
-Pandas provides a `to_csv` function to write dataframes to files.
+pandas provides a `to_csv` function to write dataframes to files.
 Applying what you've learned about reading from files,
 write one of your dataframes to a file called `processed.csv`.
 You can use `help` to get information on how to use `to_csv`.
@@ -418,7 +418,7 @@ help(data_americas.to_csv)
 help(pd.read_csv)
 ```
 
-Note that `help(to_csv)` or `help(pd.to_csv)` throws an error! This is due to the fact that `to_csv` is not a global Pandas function, but
+Note that `help(to_csv)` or `help(pd.to_csv)` throws an error! This is due to the fact that `to_csv` is not a global pandas function, but
 a member function of DataFrames. This means you can only call it on an instance of a DataFrame
 e.g., `data_americas.to_csv` or `data_oceania.to_csv`
 
@@ -430,7 +430,7 @@ e.g., `data_americas.to_csv` or `data_oceania.to_csv`
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
-- Use the Pandas library to get basic statistics out of tabular data.
+- Use the pandas library to get basic statistics out of tabular data.
 - Use `index_col` to specify that a column's values should be used as row headings.
 - Use `DataFrame.info` to find out more about a dataframe.
 - The `DataFrame.columns` variable stores information about the dataframe's columns.

--- a/episodes/08-data-frames.md
+++ b/episodes/08-data-frames.md
@@ -1,12 +1,12 @@
 ---
-title: Pandas DataFrames
+title: pandas DataFrames
 teaching: 15
 exercises: 15
 ---
 
 ::::::::::::::::::::::::::::::::::::::: objectives
 
-- Select individual values from a Pandas dataframe.
+- Select individual values from a pandas dataframe.
 - Select entire rows or entire columns from a dataframe.
 - Select a subset of both rows and columns from a dataframe in a single operation.
 - Select a subset of a dataframe by a single Boolean criterion.
@@ -19,16 +19,16 @@ exercises: 15
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-## Note about Pandas DataFrames/Series
+## Note about pandas DataFrames/Series
 
 A [DataFrame][pandas-dataframe] is a collection of [Series][pandas-series];
-The DataFrame is the way Pandas represents a table, and Series is the data-structure
-Pandas use to represent a column.
+The DataFrame is the way pandas represents a table, and Series is the data-structure
+pandas use to represent a column.
 
-Pandas is built on top of the [Numpy][numpy] library, which in practice means that
-most of the methods defined for Numpy Arrays apply to Pandas Series/DataFrames.
+pandas is built on top of the [Numpy][numpy] library, which in practice means that
+most of the methods defined for Numpy Arrays apply to pandas Series/DataFrames.
 
-What makes Pandas so attractive is the powerful interface to access individual records
+What makes pandas so attractive is the powerful interface to access individual records
 of the table, proper handling of missing values, and relational-databases operations
 between DataFrames.
 
@@ -244,7 +244,7 @@ has not been covered in the course so far.
 * The axis=1 argument needs to be explained clearly.
 :::::::::::::::::::::::::::::::::::::::::::::::::
 
-Pandas vectorizing methods and grouping operations are features that provide users
+pandas vectorizing methods and grouping operations are features that provide users
 much flexibility to analyse their data.
 
 For instance, let's say we want to have a clearer view on how the European countries
@@ -327,7 +327,7 @@ print(data.groupby(wealth_score).sum())
 
 ## Selection of Individual Values
 
-Assume Pandas has been imported into your notebook
+Assume pandas has been imported into your notebook
 and the Gapminder GDP data for Europe has been loaded:
 
 ```python
@@ -364,7 +364,7 @@ The output is
 
 1. Do the two statements below produce the same output?
 2. Based on this,
-  what rule governs what is included (or not) in numerical slices and named slices in Pandas?
+  what rule governs what is included (or not) in numerical slices and named slices in pandas?
 
 ```python
 print(data_europe.iloc[0:2, 0:2])
@@ -463,7 +463,7 @@ which has index 1).
 fourth.to_csv('result.csv')
 ```
 
-The final step is to write the data that we have been working on to a csv file. Pandas makes this easy
+The final step is to write the data that we have been working on to a csv file. pandas makes this easy
 with the `to_csv()` function. The only required argument to the function is the filename. Note that the
 file will be written in the directory from which you started the Jupyter or Python session.
 
@@ -505,7 +505,7 @@ You can use these functions whenever you want to get the row index of the minimu
 
 ## Practice with Selection
 
-Assume Pandas has been imported and the Gapminder GDP data for Europe has been loaded.
+Assume pandas has been imported and the Gapminder GDP data for Europe has been loaded.
 Write an expression to select each of the following:
 
 1. GDP per capita for all countries in 1982.
@@ -536,7 +536,7 @@ data.loc['Denmark',:]
 data.loc[:,'gdpPercap_1985':]
 ```
 
-Pandas is smart enough to recognize the number at the end of the column label and does not give you an error, although no column named `gdpPercap_1985` actually exists. This is useful if new columns are added to the CSV file later.
+pandas is smart enough to recognize the number at the end of the column label and does not give you an error, although no column named `gdpPercap_1985` actually exists. This is useful if new columns are added to the CSV file later.
 
 4:
 
@@ -735,7 +735,7 @@ This command returns:
 
 You can use `help()` or <kbd>Shift</kbd>\+<kbd>Tab</kbd> to get more information about what these methods do.
 
-Assume Pandas has been imported and the Gapminder GDP data for Europe has been loaded as `data`.  Then, use `dir()`
+Assume pandas has been imported and the Gapminder GDP data for Europe has been loaded as `data`.  Then, use `dir()`
 to find the function that prints out the median per-capita GDP across all European countries for each year that information is available.
 
 :::::::::::::::  solution

--- a/episodes/09-plotting.md
+++ b/episodes/09-plotting.md
@@ -60,9 +60,9 @@ if several are created by a single cell.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-## Plot data directly from a [`Pandas dataframe`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).
+## Plot data directly from a [`pandas dataframe`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).
 
-- We can also plot [Pandas dataframes](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html).
+- We can also plot [pandas dataframes](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html).
 - Before plotting, we convert the column headings from a `string` to `integer` data type, since they represent numerical values,
   using [str.replace()](https://pandas.pydata.org/docs/reference/api/pandas.Series.str.replace.html) to remove the `gpdPercap_`
   prefix and then [astype(int)](https://pandas.pydata.org/docs/reference/api/pandas.Series.astype.html)
@@ -77,7 +77,7 @@ data = pd.read_csv('data/gapminder_gdp_oceania.csv', index_col='country')
 # The current column names are structured as 'gdpPercap_(year)', 
 # so we want to keep the (year) part only for clarity when plotting GDP vs. years
 # To do this we use replace(), which removes from the string the characters stated in the argument
-# This method works on strings, so we use replace() from Pandas Series.str vectorized string functions
+# This method works on strings, so we use replace() from pandas Series.str vectorized string functions
 
 years = data.columns.str.replace('gdpPercap_', '')
 
@@ -376,7 +376,7 @@ Whenever you are generating plots to go into a paper or a presentation, there ar
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
 - [`matplotlib`](https://matplotlib.org/) is the most widely used scientific plotting library in Python.
-- Plot data directly from a Pandas dataframe.
+- Plot data directly from a pandas dataframe.
 - Select and transform data, then plot it.
 - Many styles of plot are available: see the [Python Graph Gallery](https://python-graph-gallery.com/matplotlib/) for more options.
 - Can plot many sets of data together.

--- a/episodes/10-lunch.md
+++ b/episodes/10-lunch.md
@@ -8,7 +8,7 @@ break: 45
 Over lunch, reflect on and discuss the following:
 
 - What sort of packages might you use in Python and why would you use them?
-- How would data need to be formatted to be used in Pandas data frames? Would the data you have meet these requirements?
+- How would data need to be formatted to be used in pandas data frames? Would the data you have meet these requirements?
 - What limitations or problems might you run into when thinking about how to apply what we've learned to your own projects or data?
 
 

--- a/episodes/14-looping-data-sets.md
+++ b/episodes/14-looping-data-sets.md
@@ -180,7 +180,7 @@ What other special strings does the [`float` function][float-function] recognize
 
 Write a program that reads in the regional data sets
 and plots the average GDP per capita for each region over time
-in a single chart. Pandas will raise an error if it encounters
+in a single chart. pandas will raise an error if it encounters
 non-numeric columns in a dataframe computation so you may need
 to either filter out those columns or tell pandas to ignore them.
 

--- a/episodes/16-writing-functions.md
+++ b/episodes/16-writing-functions.md
@@ -621,7 +621,7 @@ density. In the model, time takes discrete values 0, 1, 2, ...
 
 :::::::::::::::::::::::::::::::::::::::::  callout
 
-## Using Functions With Conditionals in Pandas
+## Using Functions With Conditionals in pandas
 
 Functions will often contain conditionals.  Here is a short example that
 will indicate which quartile the argument is in based on hand-coded values
@@ -652,7 +652,7 @@ calculate_life_quartile(62.5)
 2
 ```
 
-That function would typically be used within a `for` loop, but Pandas has
+That function would typically be used within a `for` loop, but pandas has
 a different, more efficient way of doing the same thing, and that is by
 *applying* a function to a dataframe or a portion of a dataframe.  Here
 is an example, using the definition above.

--- a/episodes/19-wrap.md
+++ b/episodes/19-wrap.md
@@ -34,13 +34,13 @@ turn out to be anything but when we have to explain them precisely.
 
 - [Jupyter](https://jupyter.org) is the home of Project Jupyter.
 
-- [Pandas](https://pandas.pydata.org) is the home of the Pandas data library.
+- [pandas](https://pandas.pydata.org) is the home of the pandas data library.
 
 - Stack Overflow's [general Python section](https://stackoverflow.com/questions/tagged/python?tab=Votes)
   can be helpful,
   as well as the sections on [NumPy](https://stackoverflow.com/questions/tagged/numpy?tab=Votes),
   [SciPy](https://stackoverflow.com/questions/tagged/scipy?tab=Votes), and
-  [Pandas](https://stackoverflow.com/questions/tagged/pandas?tab=Votes).
+  [pandas](https://stackoverflow.com/questions/tagged/pandas?tab=Votes).
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 


### PR DESCRIPTION
## What this PR does
Changes "Pandas" to "pandas" in all lesson files to match the official pandas brand guidelines.

## Why this is useful
- Follows official pandas brand guidelines (lowercase even at start of sentences)
- Maintains consistency with pandas documentation
- Resolves issue #714

## Files changed
All `.md` files in the `episodes/` folder have been updated.

## How to check
1. View the files changed in this PR
2. Confirm all instances of "Pandas" are now "pandas"

Closes #714